### PR TITLE
Support s3 compactible implementation with vitrual_host_style

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -83,6 +83,7 @@ type Config struct {
 	HTTPConfig         HTTPConfig        `yaml:"http_config"`
 	TraceConfig        TraceConfig       `yaml:"trace"`
 	ListObjectsVersion string            `yaml:"list_objects_version"`
+	LookupStyle        string            `yaml:"lookup_style"`
 	// PartSize used for multipart upload. Only used if uploaded object size is known and larger than configured PartSize.
 	// NOTE we need to make sure this number does not produce more parts than 10 000.
 	PartSize    uint64    `yaml:"part_size"`
@@ -265,10 +266,11 @@ func NewBucketWithConfig(logger log.Logger, config Config, component string) (*B
 	}
 
 	client, err := minio.New(config.Endpoint, &minio.Options{
-		Creds:     credentials.NewChainCredentials(chain),
-		Secure:    !config.Insecure,
-		Region:    config.Region,
-		Transport: rt,
+		Creds:        credentials.NewChainCredentials(chain),
+		Secure:       !config.Insecure,
+		Region:       config.Region,
+		Transport:    rt,
+		BucketLookup: withLookupStyle(config.LookupStyle),
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "initialize s3 client")
@@ -331,6 +333,17 @@ func NewBucketWithConfig(logger log.Logger, config Config, component string) (*B
 	return bkt, nil
 }
 
+func withLookupStyle(style string) minio.BucketLookupType {
+	switch style {
+	case "vhost":
+		return minio.BucketLookupDNS
+	case "path":
+		return minio.BucketLookupPath
+	default:
+		return minio.BucketLookupAuto
+	}
+}
+
 // Name returns the bucket name for s3.
 func (b *Bucket) Name() string {
 	return b.name
@@ -360,6 +373,10 @@ func validate(conf Config) error {
 
 	if conf.SSEConfig.Type == SSEKMS && conf.SSEConfig.KMSKeyID == "" {
 		return errors.New("kms_key_id must be set if sse_config.type is set to 'SSE-KMS'")
+	}
+
+	if conf.LookupStyle != "" && conf.LookupStyle != "vhost" && conf.LookupStyle != "path" {
+		return errors.New("lookup_style must be set to 'path' or 'vhost'")
 	}
 
 	return nil


### PR DESCRIPTION
The BucketLookup param in minio.Options is not exposed in s3 config. I suppose we should make this params can be configurable for using.

<img width="790" alt="image" src="https://user-images.githubusercontent.com/501763/165889510-d16a4987-24a4-4bfe-85e6-e09a36fd19ad.png">