### PR TITLE
Log deprecation notice when MSI Resource is configured for Azure

### DIFF
--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -143,6 +143,10 @@ func NewBucket(logger log.Logger, azureConfig []byte, component string) (*Bucket
 		return nil, err
 	}
 
+	if conf.MSIResource != "" {
+		level.Warn(logger).Log("msg", "The field msi_resource has been deprecated and should no longer be set")
+	}
+
 	return NewBucketWithConfig(logger, conf, component)
 }
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "s3:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos Objstore <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/objstore/pull/<PR-id>
    <Component> Component affected by your changes such as s3, azure, cos.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

This change adds a log when the MSI Resource is set in the Azure configuration. The purpose is to make end users aware of the deprecation so that they stop configuring this parameter.

## Verification

<!-- How you tested it? How do you know it works? -->

Built a fork that I tested in my own cluster.
