### PR TITLE
S3: Support specifying S3 storage class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Added
 - [#15](https://github.com/thanos-io/objstore/pull/15) Add Oracle Cloud Infrastructure Object Storage Bucket support.
+- [#25](https://github.com/thanos-io/objstore/pull/25) S3: Support specifying S3 storage class.
 
 ### Changed
 


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "s3:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos Objstore <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/objstore/pull/<PR-id>
    <Component> Component affected by your changes such as s3, azure, cos.
-->

## Changes

<!-- Enumerate changes you made -->

For https://github.com/thanos-io/thanos/issues/5663, enable specifying S3 storage class by specifying it in config.put_user_metadata. For example launching the sidecar with a `--objstore.config-file` as follows stores all S3 files with storage class of ` STANDARD_IA`

```yaml
type: S3
prefix: thanos-test-standard-ia
config:
  endpoint: s3.us-east-1.amazonaws.com
  region: us-east-1
  bucket: MY_BUCKET
  put_user_metadata:
    X-Amz-Storage-Class: STANDARD_IA
  trace:
    enable: true
```

while using the following config file uses the default storage class of `STANDARD`

```yaml
type: S3
prefix: thanos-test-standard-ia
config:
  endpoint: s3.us-east-1.amazonaws.com
  region: us-east-1
  bucket: MY_BUCKET
  trace:
    enable: true
```

## Verification

<!-- How you tested it? How do you know it works? -->

Added unit tests.

Manual tests launching the sidecar with the two configurations listed above, doing `rm ${PROM_ROOT}/data/thanos.shipper.json` before that to force uploading files, and with a prometheus instance with small block duration to force upload.

```go
${PROM_ROOT}/prometheus --config.file=${PROM_ROOT}/prometheus.yml \
  --storage.tsdb.min-block-duration=1m \
  --storage.tsdb.max-block-duration=1m
```


