### PR TITLE
Add ContextWithTracer()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ## Unreleased
 
 ### Fixed
+- [#33](https://github.com/thanos-io/objstore/pull/33) Tracing: Add `ContextWithTracer()` to inject the tracer into the context.
 
 ### Added
 - [#15](https://github.com/thanos-io/objstore/pull/15) Add Oracle Cloud Infrastructure Object Storage Bucket support.

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -29,6 +29,11 @@ type Tracer interface {
 	GetTraceIDFromSpanContext(ctx opentracing.SpanContext) (string, bool)
 }
 
+// ContextWithTracer returns a new `context.Context` that holds a reference to given opentracing.Tracer.
+func ContextWithTracer(ctx context.Context, tracer opentracing.Tracer) context.Context {
+	return context.WithValue(ctx, tracerKey, tracer)
+}
+
 // tracerFromContext extracts opentracing.Tracer from the given context.
 func tracerFromContext(ctx context.Context) opentracing.Tracer {
 	val := ctx.Value(tracerKey)


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Currently it's not possible to set the `tracerKey` expected by the package to get the object store client tracing work. In this PR I'm adding the function `ContextWithTracer()` which is a copy of the Thanos one. Then, in Thanos, we can remove the function is use this one instead.

Fixes #30

## Verification

N/A
