### PR TITLE
azure: Fix ignored options when creating shared credential Azure client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Fixed
 - [#33](https://github.com/thanos-io/objstore/pull/33) Tracing: Add `ContextWithTracer()` to inject the tracer into the context.
+- [#34](https://github.com/thanos-io/objstore/pull/34) Fix ignored options when creating shared credential Azure client.
 
 ### Added
 - [#15](https://github.com/thanos-io/objstore/pull/15) Add Oracle Cloud Infrastructure Object Storage Bucket support.

--- a/providers/azure/helpers.go
+++ b/providers/azure/helpers.go
@@ -43,7 +43,7 @@ func getContainerClient(conf Config) (*azblob.ContainerClient, error) {
 		if err != nil {
 			return nil, err
 		}
-		containerClient, err := azblob.NewContainerClientWithSharedKey(containerURL, cred, nil)
+		containerClient, err := azblob.NewContainerClientWithSharedKey(containerURL, cred, opt)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "s3:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos Objstore <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/objstore/pull/<PR-id>
    <Component> Component affected by your changes such as s3, azure, cos.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

Set client options when creating a Azure client with shared key. Before this the option was only set to clients using MSI authentication.

## Verification

<!-- How you tested it? How do you know it works? -->

Should not require verification as the same option is passed to the MSI client.
