### PR TITLE
s3: add support for session token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#15](https://github.com/thanos-io/objstore/pull/15) Add Oracle Cloud Infrastructure Object Storage Bucket support.
 - [#25](https://github.com/thanos-io/objstore/pull/25) S3: Support specifying S3 storage class.
 - [#32](https://github.com/thanos-io/objstore/pull/32) Swift: Support authentication using application credentials.
+- [#41](https://github.com/thanos-io/objstore/pull/41) S3: Support S3 session token.
 
 ### Changed
 - [#38](https://github.com/thanos-io/objstore/pull/38) *: Upgrade minio-go version to `v7.0.45`.

--- a/providers/s3/s3.go
+++ b/providers/s3/s3.go
@@ -130,6 +130,7 @@ type Config struct {
 	Insecure           bool               `yaml:"insecure"`
 	SignatureV2        bool               `yaml:"signature_version2"`
 	SecretKey          string             `yaml:"secret_key"`
+	SessionToken       string             `yaml:"session_token"`
 	PutUserMetadata    map[string]string  `yaml:"put_user_metadata"`
 	HTTPConfig         exthttp.HTTPConfig `yaml:"http_config"`
 	TraceConfig        TraceConfig        `yaml:"trace"`
@@ -228,6 +229,7 @@ func NewBucketWithConfig(logger log.Logger, config Config, component string) (*B
 			Value: credentials.Value{
 				AccessKeyID:     config.AccessKey,
 				SecretAccessKey: config.SecretKey,
+				SessionToken:    config.SessionToken,
 				SignerType:      credentials.SignatureV4,
 			},
 		})}
@@ -552,10 +554,11 @@ func (b *Bucket) getServerSideEncryption(ctx context.Context) (encrypt.ServerSid
 
 func configFromEnv() Config {
 	c := Config{
-		Bucket:    os.Getenv("S3_BUCKET"),
-		Endpoint:  os.Getenv("S3_ENDPOINT"),
-		AccessKey: os.Getenv("S3_ACCESS_KEY"),
-		SecretKey: os.Getenv("S3_SECRET_KEY"),
+		Bucket:       os.Getenv("S3_BUCKET"),
+		Endpoint:     os.Getenv("S3_ENDPOINT"),
+		AccessKey:    os.Getenv("S3_ACCESS_KEY"),
+		SecretKey:    os.Getenv("S3_SECRET_KEY"),
+		SessionToken: os.Getenv("S3_SESSION_TOKEN"),
 	}
 
 	c.Insecure, _ = strconv.ParseBool(os.Getenv("S3_INSECURE"))

--- a/providers/s3/s3_test.go
+++ b/providers/s3/s3_test.go
@@ -233,6 +233,21 @@ http_config:
 	testutil.Ok(t, validate(cfg2))
 
 	testutil.Equals(t, "bucket-owner-full-control", cfg2.PutUserMetadata["X-Amz-Acl"])
+
+	input3 := []byte(`bucket: "bucket-name"
+endpoint: "s3-endpoint"
+access_key: "access_key"
+insecure: false
+signature_version2: false
+secret_key: "secret_key"
+session_token: "session_token"
+http_config:
+  idle_conn_timeout: 0s`)
+	cfg3, err := parseConfig(input3)
+	testutil.Ok(t, err)
+	testutil.Ok(t, validate(cfg3))
+
+	testutil.Equals(t, "session_token", cfg3.SessionToken)
 }
 
 func TestParseConfig_PartSize(t *testing.T) {


### PR DESCRIPTION
Fixes #17 
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "s3:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos Objstore <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/objstore/pull/<PR-id>
    <Component> Component affected by your changes such as s3, azure, cos.
-->

* [x] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

* s3: add support for session token 

## Verification

<!-- How you tested it? How do you know it works? -->
