### PR TITLE
Add defensive copy of objects in InMemBucket

### DIFF
--- a/inmem.go
+++ b/inmem.go
@@ -34,10 +34,18 @@ func NewInMemBucket() *InMemBucket {
 	}
 }
 
-// Objects returns internally stored objects.
+// Objects returns a copy of the internally stored objects.
 // NOTE: For assert purposes.
 func (b *InMemBucket) Objects() map[string][]byte {
-	return b.objects
+	b.mtx.RLock()
+	defer b.mtx.RUnlock()
+
+	objs := make(map[string][]byte)
+	for k, v := range b.objects {
+		objs[k] = v
+	}
+
+	return objs
 }
 
 // Iter calls f for each entry in the given directory. The argument to f is the full


### PR DESCRIPTION
## Changes

Add locking and return a copy of the internally stored objects in InMemBucket. This fixes a race condition that can be triggered if the result of `.Objects()` is read while another goroutine modifies the objects (such as uploading a new file).

Noticed in grafana/mimir#4021

Signed-off-by: Nick Pillitteri <nick.pillitteri@grafana.com>

## Verification

Tested repeatedly in a Mimir checkout and was unable to trigger the race condition:

```
go test -race -run=TestDeleteTenant -count=100 ./pkg/compactor/
```

* [ ] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.
