### PR TITLE
filesystem: abort filesystem bucket operations if the context has been cancelled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#15](https://github.com/thanos-io/objstore/pull/15) Add Oracle Cloud Infrastructure Object Storage Bucket support.
 - [#25](https://github.com/thanos-io/objstore/pull/25) S3: Support specifying S3 storage class.
 - [#32](https://github.com/thanos-io/objstore/pull/32) Swift: Support authentication using application credentials.
+- [#43](https://github.com/thanos-io/objstore/pull/43) filesystem: abort filesystem bucket operations if the context has been cancelled
 
 ### Changed
 - [#38](https://github.com/thanos-io/objstore/pull/38) *: Upgrade minio-go version to `v7.0.45`.

--- a/providers/filesystem/filesystem.go
+++ b/providers/filesystem/filesystem.go
@@ -53,10 +53,8 @@ func NewBucket(rootDir string) (*Bucket, error) {
 // Iter calls f for each entry in the given directory. The argument to f is the full
 // object name including the prefix of the inspected directory.
 func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error, options ...objstore.IterOption) error {
-	select {
-	case <-ctx.Done():
+	if ctx.Err() != nil {
 		return ctx.Err()
-	default:
 	}
 
 	params := objstore.ApplyIterOptions(options...)
@@ -126,10 +124,8 @@ func (r *rangeReaderCloser) Close() error {
 
 // Attributes returns information about the specified object.
 func (b *Bucket) Attributes(ctx context.Context, name string) (objstore.ObjectAttributes, error) {
-	select {
-	case <-ctx.Done():
+	if ctx.Err() != nil {
 		return objstore.ObjectAttributes{}, ctx.Err()
-	default:
 	}
 
 	file := filepath.Join(b.rootDir, name)
@@ -146,10 +142,8 @@ func (b *Bucket) Attributes(ctx context.Context, name string) (objstore.ObjectAt
 
 // GetRange returns a new range reader for the given object name and range.
 func (b *Bucket) GetRange(ctx context.Context, name string, off, length int64) (io.ReadCloser, error) {
-	select {
-	case <-ctx.Done():
+	if ctx.Err() != nil {
 		return nil, ctx.Err()
-	default:
 	}
 
 	if name == "" {
@@ -182,10 +176,8 @@ func (b *Bucket) GetRange(ctx context.Context, name string, off, length int64) (
 
 // Exists checks if the given directory exists in memory.
 func (b *Bucket) Exists(ctx context.Context, name string) (bool, error) {
-	select {
-	case <-ctx.Done():
+	if ctx.Err() != nil {
 		return false, ctx.Err()
-	default:
 	}
 
 	info, err := os.Stat(filepath.Join(b.rootDir, name))
@@ -200,10 +192,8 @@ func (b *Bucket) Exists(ctx context.Context, name string) (bool, error) {
 
 // Upload writes the file specified in src to into the memory.
 func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader) (err error) {
-	select {
-	case <-ctx.Done():
+	if ctx.Err() != nil {
 		return ctx.Err()
-	default:
 	}
 
 	file := filepath.Join(b.rootDir, name)
@@ -242,10 +232,8 @@ func isDirEmpty(name string) (ok bool, err error) {
 
 // Delete removes all data prefixed with the dir.
 func (b *Bucket) Delete(ctx context.Context, name string) error {
-	select {
-	case <-ctx.Done():
+	if ctx.Err() != nil {
 		return ctx.Err()
-	default:
 	}
 
 	file := filepath.Join(b.rootDir, name)

--- a/providers/filesystem/filesystem.go
+++ b/providers/filesystem/filesystem.go
@@ -53,6 +53,12 @@ func NewBucket(rootDir string) (*Bucket, error) {
 // Iter calls f for each entry in the given directory. The argument to f is the full
 // object name including the prefix of the inspected directory.
 func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error, options ...objstore.IterOption) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	params := objstore.ApplyIterOptions(options...)
 	absDir := filepath.Join(b.rootDir, dir)
 	info, err := os.Stat(absDir)
@@ -119,7 +125,13 @@ func (r *rangeReaderCloser) Close() error {
 }
 
 // Attributes returns information about the specified object.
-func (b *Bucket) Attributes(_ context.Context, name string) (objstore.ObjectAttributes, error) {
+func (b *Bucket) Attributes(ctx context.Context, name string) (objstore.ObjectAttributes, error) {
+	select {
+	case <-ctx.Done():
+		return objstore.ObjectAttributes{}, ctx.Err()
+	default:
+	}
+
 	file := filepath.Join(b.rootDir, name)
 	stat, err := os.Stat(file)
 	if err != nil {
@@ -133,7 +145,13 @@ func (b *Bucket) Attributes(_ context.Context, name string) (objstore.ObjectAttr
 }
 
 // GetRange returns a new range reader for the given object name and range.
-func (b *Bucket) GetRange(_ context.Context, name string, off, length int64) (io.ReadCloser, error) {
+func (b *Bucket) GetRange(ctx context.Context, name string, off, length int64) (io.ReadCloser, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	if name == "" {
 		return nil, errors.New("object name is empty")
 	}
@@ -163,7 +181,13 @@ func (b *Bucket) GetRange(_ context.Context, name string, off, length int64) (io
 }
 
 // Exists checks if the given directory exists in memory.
-func (b *Bucket) Exists(_ context.Context, name string) (bool, error) {
+func (b *Bucket) Exists(ctx context.Context, name string) (bool, error) {
+	select {
+	case <-ctx.Done():
+		return false, ctx.Err()
+	default:
+	}
+
 	info, err := os.Stat(filepath.Join(b.rootDir, name))
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -175,7 +199,13 @@ func (b *Bucket) Exists(_ context.Context, name string) (bool, error) {
 }
 
 // Upload writes the file specified in src to into the memory.
-func (b *Bucket) Upload(_ context.Context, name string, r io.Reader) (err error) {
+func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader) (err error) {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	file := filepath.Join(b.rootDir, name)
 	if err := os.MkdirAll(filepath.Dir(file), os.ModePerm); err != nil {
 		return err
@@ -211,7 +241,13 @@ func isDirEmpty(name string) (ok bool, err error) {
 }
 
 // Delete removes all data prefixed with the dir.
-func (b *Bucket) Delete(_ context.Context, name string) error {
+func (b *Bucket) Delete(ctx context.Context, name string) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	file := filepath.Join(b.rootDir, name)
 	for file != b.rootDir {
 		if err := os.RemoveAll(file); err != nil {

--- a/providers/filesystem/filesystem_test.go
+++ b/providers/filesystem/filesystem_test.go
@@ -4,6 +4,7 @@
 package filesystem
 
 import (
+	"bytes"
 	"context"
 	"strings"
 	"sync"
@@ -43,4 +44,91 @@ func TestDelete_EmptyDirDeletionRaceCondition(t *testing.T) {
 		close(start)
 		group.Wait()
 	}
+}
+
+func TestIter_CancelledContext(t *testing.T) {
+	b, err := NewBucket(t.TempDir())
+	testutil.Ok(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = b.Iter(ctx, "", func(s string) error {
+		return nil
+	})
+
+	testutil.NotOk(t, err)
+	testutil.Equals(t, context.Canceled, err)
+}
+
+func TestGet_CancelledContext(t *testing.T) {
+	b, err := NewBucket(t.TempDir())
+	testutil.Ok(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = b.Get(ctx, "some-file")
+	testutil.NotOk(t, err)
+	testutil.Equals(t, context.Canceled, err)
+}
+
+func TestAttributes_CancelledContext(t *testing.T) {
+	b, err := NewBucket(t.TempDir())
+	testutil.Ok(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = b.Attributes(ctx, "some-file")
+	testutil.NotOk(t, err)
+	testutil.Equals(t, context.Canceled, err)
+}
+
+func TestGetRange_CancelledContext(t *testing.T) {
+	b, err := NewBucket(t.TempDir())
+	testutil.Ok(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = b.GetRange(ctx, "some-file", 0, 100)
+	testutil.NotOk(t, err)
+	testutil.Equals(t, context.Canceled, err)
+}
+
+func TestExists_CancelledContext(t *testing.T) {
+	b, err := NewBucket(t.TempDir())
+	testutil.Ok(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = b.Exists(ctx, "some-file")
+	testutil.NotOk(t, err)
+	testutil.Equals(t, context.Canceled, err)
+}
+
+func TestUpload_CancelledContext(t *testing.T) {
+	b, err := NewBucket(t.TempDir())
+	testutil.Ok(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = b.Upload(ctx, "some-file", bytes.NewReader([]byte("file content")))
+	testutil.NotOk(t, err)
+	testutil.Equals(t, context.Canceled, err)
+}
+
+func TestDelete_CancelledContext(t *testing.T) {
+	b, err := NewBucket(t.TempDir())
+	testutil.Ok(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = b.Delete(ctx, "some-file")
+	testutil.NotOk(t, err)
+	testutil.Equals(t, context.Canceled, err)
 }


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos Objstore <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/objstore/pull/<PR-id>
    <Component> Component affected by your changes such as s3, azure, cos.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Changed all of the `filesystem.Bucket` methods to return early if the context has been cancelled.

This makes testing cancellation behaviour of consuming applications easier (see https://github.com/grafana/mimir/pull/4061 for an example), and brings the behaviour of the filesystem bucket into line with the other providers.

## Verification

I've added tests for cancellation behaviour in `filesystem_test.go`, and the existing acceptance tests should catch any regressions in existing behaviour.
