### PR TITLE
Add new metric to count total number of fetched bytes from bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#32](https://github.com/thanos-io/objstore/pull/32) Swift: Support authentication using application credentials.
 - [#41](https://github.com/thanos-io/objstore/pull/41) S3: Support S3 session token.
 - [#43](https://github.com/thanos-io/objstore/pull/43) filesystem: abort filesystem bucket operations if the context has been cancelled
+- [#44](https://github.com/thanos-io/objstore/pull/44) Add new metric to count total number of fetched bytes from bucket
 
 ### Changed
 - [#38](https://github.com/thanos-io/objstore/pull/38) *: Upgrade minio-go version to `v7.0.45`.


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos Objstore <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/objstore/pull/<PR-id>
    <Component> Component affected by your changes such as s3, azure, cos.
-->

* [X] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

We are using a cloud provider which bills us on the outgoing trafic, so it is useful for me to know how many bytes are downloaded from the bucket.
I thought maybe others can have the same needs.

Of course if you think that could be useful but want a different implementation, let me know.

## Verification

updated `TestDownloadUploadDirConcurrency` test in `objstore_test.go` but I can add more tests if you want.

Thanks,
