### PR TITLE
azure: Support using connection string authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
     > This also changes the behaviour of `client.NewBucket`. Now it returns, uninstrumented and untraced bucket.
     You can combine `objstore.WrapWithMetrics` and `tracing/{opentelemetry,opentracing}.WrapWithTraces` to have old behavior.
 - [#64](https://github.com/thanos-io/objstore/pull/64) OCI: OKE Workload Identity support.
+- [#51](https://github.com/thanos-io/objstore/pull/51) azure: Support using connection string authentication.
 
 ### Changed
 - [#38](https://github.com/thanos-io/objstore/pull/38) *: Upgrade minio-go version to `v7.0.45`.

--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ type: AZURE
 config:
   storage_account: ""
   storage_account_key: ""
+  storage_connection_string: ""
   container: ""
   endpoint: ""
   user_assigned_id: ""
@@ -452,6 +453,8 @@ prefix: ""
 If `msi_resource` is used, authentication is done via system-assigned managed identity. The value for Azure should be `https://<storage-account-name>.blob.core.windows.net`.
 
 If `user_assigned_id` is used, authentication is done via user-assigned managed identity. When using `user_assigned_id` the `msi_resource` defaults to `https://<storage_account>.<endpoint>`
+
+If `storage_connection_string` is set, the values of `storage_account` and `endpoint` values will not be used. Use this method over `storage_account_key` if you need to authenticate via a SAS token.
 
 The generic `max_retries` will be used as value for the `pipeline_config`'s `max_tries` and `reader_config`'s `max_retry_requests`. For more control, `max_retries` could be ignored (0) and one could set specific retry values.
 

--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -44,15 +44,16 @@ var DefaultConfig = Config{
 
 // Config Azure storage configuration.
 type Config struct {
-	StorageAccountName string             `yaml:"storage_account"`
-	StorageAccountKey  string             `yaml:"storage_account_key"`
-	ContainerName      string             `yaml:"container"`
-	Endpoint           string             `yaml:"endpoint"`
-	UserAssignedID     string             `yaml:"user_assigned_id"`
-	MaxRetries         int                `yaml:"max_retries"`
-	ReaderConfig       ReaderConfig       `yaml:"reader_config"`
-	PipelineConfig     PipelineConfig     `yaml:"pipeline_config"`
-	HTTPConfig         exthttp.HTTPConfig `yaml:"http_config"`
+	StorageAccountName      string             `yaml:"storage_account"`
+	StorageAccountKey       string             `yaml:"storage_account_key"`
+	StorageConnectionString string             `yaml:"storage_connection_string"`
+	ContainerName           string             `yaml:"container"`
+	Endpoint                string             `yaml:"endpoint"`
+	UserAssignedID          string             `yaml:"user_assigned_id"`
+	MaxRetries              int                `yaml:"max_retries"`
+	ReaderConfig            ReaderConfig       `yaml:"reader_config"`
+	PipelineConfig          PipelineConfig     `yaml:"pipeline_config"`
+	HTTPConfig              exthttp.HTTPConfig `yaml:"http_config"`
 
 	// Deprecated: Is automatically set by the Azure SDK.
 	MSIResource string `yaml:"msi_resource"`
@@ -74,6 +75,14 @@ func (conf *Config) validate() error {
 	var errMsg []string
 	if conf.UserAssignedID != "" && conf.StorageAccountKey != "" {
 		errMsg = append(errMsg, "user_assigned_id cannot be set when using storage_account_key authentication")
+	}
+
+	if conf.UserAssignedID != "" && conf.StorageConnectionString != "" {
+		errMsg = append(errMsg, "user_assigned_id cannot be set when using storage_connection_string authentication")
+	}
+
+	if conf.StorageAccountKey != "" && conf.StorageConnectionString != "" {
+		errMsg = append(errMsg, "storage_account_key and storage_connection_string cannot both be set")
 	}
 
 	if conf.StorageAccountName == "" {

--- a/providers/azure/azure_test.go
+++ b/providers/azure/azure_test.go
@@ -132,6 +132,16 @@ container: "MyContainer"`),
 		wantFailParse:    false,
 		wantFailValidate: false,
 	},
+	{
+		name: "Valid User Assigned and Connection String set",
+		config: []byte(`storage_account: "myAccount"
+storage_account_key: ""
+user_assigned_id: "1234-56578678-655"
+storage_connection_string: "myConnectionString"
+container: "MyContainer"`),
+		wantFailParse:    false,
+		wantFailValidate: true,
+	},
 }
 
 func TestConfig_validate(t *testing.T) {

--- a/providers/azure/helpers.go
+++ b/providers/azure/helpers.go
@@ -38,6 +38,16 @@ func getContainerClient(conf Config) (*container.Client, error) {
 			Transport: &http.Client{Transport: dt},
 		},
 	}
+
+	// Use connection string if set
+	if conf.StorageConnectionString != "" {
+		containerClient, err := container.NewClientFromConnectionString(conf.StorageConnectionString, conf.ContainerName, opt)
+		if err != nil {
+			return nil, err
+		}
+		return containerClient, nil
+	}
+
 	containerURL := fmt.Sprintf("https://%s.%s/%s", conf.StorageAccountName, conf.Endpoint, conf.ContainerName)
 
 	// Use shared keys if set


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "s3:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos Objstore <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/objstore/pull/<PR-id>
    <Component> Component affected by your changes such as s3, azure, cos.
-->

* [x] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Added an additional option `storage_connection_string` to Azure config to use a connection string rather than a key.  This is needed in limited privilege scenarios where only a SAS token is available and not  full access key.  When provided, the value is forwarded on to the Azure SDK method for creating a client that accepts a connection string.  

Existing consumers will be unaffected as using this new path must be opted into with a non-empty value for the new config option.

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
Using a connection string with a SAS token creates a client successfully.  Further verified that running a patched version of loki consuming this library passing through SAS tokens as the authentication method works.