### PR TITLE
S3: Return context cancellation from Iter when applicable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ### Fixed
 - [#33](https://github.com/thanos-io/objstore/pull/33) Tracing: Add `ContextWithTracer()` to inject the tracer into the context.
 - [#34](https://github.com/thanos-io/objstore/pull/34) Fix ignored options when creating shared credential Azure client.
+- [#62](https://github.com/thanos-io/objstore/pull/62) S3: Fix ignored context cancellation in `Iter` method. 
 
 ### Added
 - [#15](https://github.com/thanos-io/objstore/pull/15) Add Oracle Cloud Infrastructure Object Storage Bucket support.

--- a/providers/s3/s3.go
+++ b/providers/s3/s3.go
@@ -418,7 +418,7 @@ func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error, opt
 		}
 	}
 
-	return nil
+	return ctx.Err()
 }
 
 func (b *Bucket) getRange(ctx context.Context, name string, off, length int64) (io.ReadCloser, error) {


### PR DESCRIPTION
## Changes

This PR returns `ctx.Err()` from the S3 `Iter` method instead of `nil` after exhausting the `ListObjects` channel.

When the context passed to the S3 Iter method is cancelled, the underlying Minio client sometimes immediately [closes the results channel](https://github.com/grafana/mimir/blob/285fa4e35dd5720e38dd0491f6ddeb51e3e81197/vendor/github.com/minio/minio-go/v7/api-list.go#L100) and returns without sending the `ctx.Err()` error. Depending on [when exactly the context is cancelled](https://github.com/grafana/mimir/blob/285fa4e35dd5720e38dd0491f6ddeb51e3e81197/vendor/github.com/minio/minio-go/v7/api-list.go#L114-L136), this can result in the `Iter` method not returning any results _and_ not returning an error indicating what happened.

Discovered while debugging grafana/mimir#5433

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "s3:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos Objstore <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/objstore/pull/<PR-id>
    <Component> Component affected by your changes such as s3, azure, cos.
-->

* [X] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Verification

Tested via [Mimir end-to-end test used to reproduce the issue](https://github.com/grafana/mimir/pull/5427). The S3 `Bucket` implementation uses the concrete Minio `Client` instead of an interface so writing a unit test would be a challenge without making quite a few changes to the `Bucket`. I can do that if you'd like but it seemed like a lot of churn for a small change.
