### PR TITLE
Add support for object attributes in Iter call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#79](https://github.com/thanos-io/objstore/pull/79) Metrics: Fix `objstore_bucket_operation_duration_seconds` for `iter` operations.
 
 ### Added
+- [#63](https://github.com/thanos-io/objstore/pull/63) Implement a `IterWithAttributes` method on the bucket client.
 - [#15](https://github.com/thanos-io/objstore/pull/15) Add Oracle Cloud Infrastructure Object Storage Bucket support.
 - [#25](https://github.com/thanos-io/objstore/pull/25) S3: Support specifying S3 storage class.
 - [#32](https://github.com/thanos-io/objstore/pull/32) Swift: Support authentication using application credentials.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ See [MAINTAINERS.md](https://github.com/thanos-io/thanos/blob/main/MAINTAINERS.m
 
 The core this module is the [`Bucket` interface](objstore.go):
 
-```go mdox-exec="sed -n '37,50p' objstore.go"
+```go mdox-exec="sed -n '39,55p' objstore.go"
 // Bucket provides read and write access to an object storage bucket.
 // NOTE: We assume strong consistency for write-read flow.
 type Bucket interface {
@@ -63,18 +63,31 @@ type Bucket interface {
 	// If object does not exist in the moment of deletion, Delete should throw error.
 	Delete(ctx context.Context, name string) error
 
+	// Name returns the bucket name for the provider.
+	Name() string
+}
 ```
 
 All [provider implementations](providers) have to implement `Bucket` interface that allows common read and write operations that all supported by all object providers. If you want to limit the code that will do bucket operation to only read access (smart idea, allowing to limit access permissions), you can use the [`BucketReader` interface](objstore.go):
 
-```go mdox-exec="sed -n '68,93p' objstore.go"
-
+```go mdox-exec="sed -n '71,106p' objstore.go"
 // BucketReader provides read access to an object storage bucket.
 type BucketReader interface {
 	// Iter calls f for each entry in the given directory (not recursive.). The argument to f is the full
 	// object name including the prefix of the inspected directory.
+
 	// Entries are passed to function in sorted order.
-	Iter(ctx context.Context, dir string, f func(string) error, options ...IterOption) error
+	Iter(ctx context.Context, dir string, f func(name string) error, options ...IterOption) error
+
+	// IterWithAttributes calls f for each entry in the given directory similar to Iter.
+	// In addition to Name, it also includes requested object attributes in the argument to f.
+	//
+	// Attributes can be requested using IterOption.
+	// Not all IterOptions are supported by all providers, requesting for an unsupported option will fail with ErrOptionNotSupported.
+	IterWithAttributes(ctx context.Context, dir string, f func(attrs IterObjectAttributes) error, options ...IterOption) error
+
+	// SupportedIterOptions returns a list of supported IterOptions by the underlying provider.
+	SupportedIterOptions() []IterOptionType
 
 	// Get returns a reader for the given object name.
 	Get(ctx context.Context, name string) (io.ReadCloser, error)
@@ -374,6 +387,7 @@ config:
       server_name: ""
       insecure_skip_verify: false
     disable_compression: false
+  chunk_size_bytes: 0
 prefix: ""
 ```
 
@@ -447,6 +461,7 @@ config:
   storage_account: ""
   storage_account_key: ""
   storage_connection_string: ""
+  storage_create_container: false
   container: ""
   endpoint: ""
   user_assigned_id: ""

--- a/inmem.go
+++ b/inmem.go
@@ -106,6 +106,20 @@ func (b *InMemBucket) Iter(_ context.Context, dir string, f func(string) error, 
 	return nil
 }
 
+func (i *InMemBucket) SupportedIterOptions() []IterOptionType {
+	return []IterOptionType{Recursive}
+}
+
+func (b *InMemBucket) IterWithAttributes(ctx context.Context, dir string, f func(attrs IterObjectAttributes) error, options ...IterOption) error {
+	if err := ValidateIterOptions(b.SupportedIterOptions(), options...); err != nil {
+		return err
+	}
+
+	return b.Iter(ctx, dir, func(name string) error {
+		return f(IterObjectAttributes{Name: name})
+	}, options...)
+}
+
 // Get returns a reader for the given object name.
 func (b *InMemBucket) Get(_ context.Context, name string) (io.ReadCloser, error) {
 	if name == "" {

--- a/objstore.go
+++ b/objstore.go
@@ -144,7 +144,7 @@ func WithRecursiveIter() IterOption {
 // WithUpdatedAt is an option that can be applied to Iter() to
 // include the last modified time in the attributes.
 // NB: Prefixes may not report last modified time.
-// This option is currently supported for the azure, aws, bos, gcs and filesystem providers.
+// This option is currently supported for the azure, s3, bos, gcs and filesystem providers.
 func WithUpdatedAt() IterOption {
 	return IterOption{
 		Type: UpdatedAt,

--- a/prefixed_bucket.go
+++ b/prefixed_bucket.go
@@ -54,6 +54,19 @@ func (p *PrefixedBucket) Iter(ctx context.Context, dir string, f func(string) er
 	}, options...)
 }
 
+func (p *PrefixedBucket) IterWithAttributes(ctx context.Context, dir string, f func(IterObjectAttributes) error, options ...IterOption) error {
+	pdir := withPrefix(p.prefix, dir)
+
+	return p.bkt.IterWithAttributes(ctx, pdir, func(attrs IterObjectAttributes) error {
+		attrs.Name = strings.TrimPrefix(attrs.Name, p.prefix+DirDelim)
+		return f(attrs)
+	}, options...)
+}
+
+func (p *PrefixedBucket) SupportedIterOptions() []IterOptionType {
+	return p.bkt.SupportedIterOptions()
+}
+
 // Get returns a reader for the given object name.
 func (p *PrefixedBucket) Get(ctx context.Context, name string) (io.ReadCloser, error) {
 	return p.bkt.Get(ctx, conditionalPrefix(p.prefix, name))

--- a/prefixed_bucket_test.go
+++ b/prefixed_bucket_test.go
@@ -74,7 +74,7 @@ func UsesPrefixTest(t *testing.T, bkt Bucket, prefix string) {
 	testutil.Ok(t, pBkt.Iter(context.Background(), "", func(fn string) error {
 		seen = append(seen, fn)
 		return nil
-	}, WithRecursiveIter))
+	}, WithRecursiveIter()))
 	expected := []string{"dir/file1.jpg", "file1.jpg"}
 	sort.Strings(expected)
 	sort.Strings(seen)

--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -193,9 +193,15 @@ func NewBucketWithConfig(logger log.Logger, conf Config, component string, wrapR
 	return bkt, nil
 }
 
-// Iter calls f for each entry in the given directory. The argument to f is the full
-// object name including the prefix of the inspected directory.
-func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error, options ...objstore.IterOption) error {
+func (b *Bucket) SupportedIterOptions() []objstore.IterOptionType {
+	return []objstore.IterOptionType{objstore.Recursive, objstore.UpdatedAt}
+}
+
+func (b *Bucket) IterWithAttributes(ctx context.Context, dir string, f func(attrs objstore.IterObjectAttributes) error, options ...objstore.IterOption) error {
+	if err := objstore.ValidateIterOptions(b.SupportedIterOptions(), options...); err != nil {
+		return err
+	}
+
 	prefix := dir
 	if prefix != "" && !strings.HasSuffix(prefix, DirDelim) {
 		prefix += DirDelim
@@ -211,7 +217,13 @@ func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error, opt
 				return err
 			}
 			for _, blob := range resp.Segment.BlobItems {
-				if err := f(*blob.Name); err != nil {
+				attrs := objstore.IterObjectAttributes{
+					Name: *blob.Name,
+				}
+				if params.LastModified {
+					attrs.SetLastModified(*blob.Properties.LastModified)
+				}
+				if err := f(attrs); err != nil {
 					return err
 				}
 			}
@@ -227,17 +239,40 @@ func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error, opt
 			return err
 		}
 		for _, blobItem := range resp.Segment.BlobItems {
-			if err := f(*blobItem.Name); err != nil {
+			attrs := objstore.IterObjectAttributes{
+				Name: *blobItem.Name,
+			}
+			if params.LastModified {
+				attrs.SetLastModified(*blobItem.Properties.LastModified)
+			}
+			if err := f(attrs); err != nil {
 				return err
 			}
 		}
 		for _, blobPrefix := range resp.Segment.BlobPrefixes {
-			if err := f(*blobPrefix.Name); err != nil {
+			if err := f(objstore.IterObjectAttributes{Name: *blobPrefix.Name}); err != nil {
 				return err
 			}
 		}
 	}
 	return nil
+}
+
+// Iter calls f for each entry in the given directory. The argument to f is the full
+// object name including the prefix of the inspected directory.
+func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error, opts ...objstore.IterOption) error {
+	// Only include recursive option since attributes are not used in this method.
+	var filteredOpts []objstore.IterOption
+	for _, opt := range opts {
+		if opt.Type == objstore.Recursive {
+			filteredOpts = append(filteredOpts, opt)
+			break
+		}
+	}
+
+	return b.IterWithAttributes(ctx, dir, func(attrs objstore.IterObjectAttributes) error {
+		return f(attrs.Name)
+	}, filteredOpts...)
 }
 
 // IsObjNotFoundErr returns true if error means that object is not found. Relevant to Get operations.

--- a/providers/bos/bos.go
+++ b/providers/bos/bos.go
@@ -176,16 +176,23 @@ func (b *Bucket) Upload(_ context.Context, name string, r io.Reader) error {
 	return nil
 }
 
-// Iter calls f for each entry in the given directory (not recursive). The argument to f is the full
-// object name including the prefix of the inspected directory.
-func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error, opt ...objstore.IterOption) error {
+func (b *Bucket) SupportedIterOptions() []objstore.IterOptionType {
+	return []objstore.IterOptionType{objstore.Recursive, objstore.UpdatedAt}
+}
+
+func (b *Bucket) IterWithAttributes(ctx context.Context, dir string, f func(attrs objstore.IterObjectAttributes) error, options ...objstore.IterOption) error {
+	if err := objstore.ValidateIterOptions(b.SupportedIterOptions(), options...); err != nil {
+		return err
+	}
+
 	if dir != "" {
 		dir = strings.TrimSuffix(dir, objstore.DirDelim) + objstore.DirDelim
 	}
 
 	delimiter := objstore.DirDelim
 
-	if objstore.ApplyIterOptions(opt...).Recursive {
+	params := objstore.ApplyIterOptions(options...)
+	if params.Recursive {
 		delimiter = ""
 	}
 
@@ -207,13 +214,25 @@ func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error, opt
 
 		marker = objects.NextMarker
 		for _, object := range objects.Contents {
-			if err := f(object.Key); err != nil {
+			attrs := objstore.IterObjectAttributes{
+				Name: object.Key,
+			}
+
+			if params.LastModified && object.LastModified != "" {
+				lastModified, err := time.Parse(time.RFC1123, object.LastModified)
+				if err != nil {
+					return fmt.Errorf("iter: get last modified: %w", err)
+				}
+				attrs.SetLastModified(lastModified)
+			}
+
+			if err := f(attrs); err != nil {
 				return err
 			}
 		}
 
 		for _, object := range objects.CommonPrefixes {
-			if err := f(object.Prefix); err != nil {
+			if err := f(objstore.IterObjectAttributes{Name: object.Prefix}); err != nil {
 				return err
 			}
 		}
@@ -222,6 +241,23 @@ func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error, opt
 		}
 	}
 	return nil
+}
+
+// Iter calls f for each entry in the given directory. The argument to f is the full
+// object name including the prefix of the inspected directory.
+func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error, opts ...objstore.IterOption) error {
+	// Only include recursive option since attributes are not used in this method.
+	var filteredOpts []objstore.IterOption
+	for _, opt := range opts {
+		if opt.Type == objstore.Recursive {
+			filteredOpts = append(filteredOpts, opt)
+			break
+		}
+	}
+
+	return b.IterWithAttributes(ctx, dir, func(attrs objstore.IterObjectAttributes) error {
+		return f(attrs.Name)
+	}, filteredOpts...)
 }
 
 // Get returns a reader for the given object name.

--- a/providers/cos/cos.go
+++ b/providers/cos/cos.go
@@ -276,7 +276,11 @@ func (b *Bucket) Delete(ctx context.Context, name string) error {
 	return nil
 }
 
-// Iter calls f for each entry in the given directory (not recursive.). The argument to f is the full
+func (b *Bucket) SupportedIterOptions() []objstore.IterOptionType {
+	return []objstore.IterOptionType{objstore.Recursive}
+}
+
+// Iter calls f for each entry in the given directory. The argument to f is the full
 // object name including the prefix of the inspected directory.
 func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error, options ...objstore.IterOption) error {
 	if dir != "" {
@@ -296,6 +300,16 @@ func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error, opt
 	}
 
 	return nil
+}
+
+func (b *Bucket) IterWithAttributes(ctx context.Context, dir string, f func(attrs objstore.IterObjectAttributes) error, options ...objstore.IterOption) error {
+	if err := objstore.ValidateIterOptions(b.SupportedIterOptions(), options...); err != nil {
+		return err
+	}
+
+	return b.Iter(ctx, dir, func(name string) error {
+		return f(objstore.IterObjectAttributes{Name: name})
+	}, options...)
 }
 
 func (b *Bucket) getRange(ctx context.Context, name string, off, length int64) (io.ReadCloser, error) {
@@ -493,7 +507,7 @@ func NewTestBucket(t testing.TB) (objstore.Bucket, func(), error) {
 			return nil, nil, err
 		}
 
-		if err := b.Iter(context.Background(), "", func(f string) error {
+		if err := b.Iter(context.Background(), "", func(_ string) error {
 			return errors.Errorf("bucket %s is not empty", c.Bucket)
 		}); err != nil {
 			return nil, nil, errors.Wrapf(err, "cos check bucket %s", c.Bucket)

--- a/providers/filesystem/filesystem_test.go
+++ b/providers/filesystem/filesystem_test.go
@@ -6,11 +6,15 @@ package filesystem
 import (
 	"bytes"
 	"context"
+	"os"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/efficientgo/core/testutil"
+
+	"github.com/thanos-io/objstore"
 )
 
 func TestDelete_EmptyDirDeletionRaceCondition(t *testing.T) {
@@ -59,6 +63,60 @@ func TestIter_CancelledContext(t *testing.T) {
 
 	testutil.NotOk(t, err)
 	testutil.Equals(t, context.Canceled, err)
+}
+
+func TestIterWithAttributes(t *testing.T) {
+	dir := t.TempDir()
+	f, err := os.CreateTemp(dir, "test")
+	testutil.Ok(t, err)
+	defer f.Close()
+
+	stat, err := f.Stat()
+	testutil.Ok(t, err)
+
+	cases := []struct {
+		name              string
+		opts              []objstore.IterOption
+		expectedUpdatedAt time.Time
+	}{
+		{
+			name: "no options",
+			opts: nil,
+		},
+		{
+			name: "with updated at",
+			opts: []objstore.IterOption{
+				objstore.WithUpdatedAt(),
+			},
+			expectedUpdatedAt: stat.ModTime(),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := NewBucket(dir)
+			testutil.Ok(t, err)
+
+			var attrs objstore.IterObjectAttributes
+
+			ctx := context.Background()
+			err = b.IterWithAttributes(ctx, "", func(objectAttrs objstore.IterObjectAttributes) error {
+				attrs = objectAttrs
+				return nil
+			}, tc.opts...)
+
+			testutil.Ok(t, err)
+
+			lastModified, ok := attrs.LastModified()
+			if zero := tc.expectedUpdatedAt.IsZero(); zero {
+				testutil.Equals(t, false, ok)
+			} else {
+				testutil.Equals(t, true, ok)
+				testutil.Equals(t, tc.expectedUpdatedAt, lastModified)
+			}
+		})
+
+	}
 }
 
 func TestGet_CancelledContext(t *testing.T) {

--- a/providers/gcs/gcs.go
+++ b/providers/gcs/gcs.go
@@ -181,31 +181,33 @@ func (b *Bucket) Name() string {
 	return b.name
 }
 
-// Iter calls f for each entry in the given directory. The argument to f is the full
-// object name including the prefix of the inspected directory.
-func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error, options ...objstore.IterOption) error {
+func (b *Bucket) SupportedIterOptions() []objstore.IterOptionType {
+	return []objstore.IterOptionType{objstore.Recursive, objstore.UpdatedAt}
+}
+
+func (b *Bucket) IterWithAttributes(ctx context.Context, dir string, f func(attrs objstore.IterObjectAttributes) error, options ...objstore.IterOption) error {
+	if err := objstore.ValidateIterOptions(b.SupportedIterOptions(), options...); err != nil {
+		return err
+	}
+
 	// Ensure the object name actually ends with a dir suffix. Otherwise we'll just iterate the
 	// object itself as one prefix item.
 	if dir != "" {
 		dir = strings.TrimSuffix(dir, DirDelim) + DirDelim
 	}
 
+	appliedOpts := objstore.ApplyIterOptions(options...)
+
 	// If recursive iteration is enabled we should pass an empty delimiter.
 	delimiter := DirDelim
-	if objstore.ApplyIterOptions(options...).Recursive {
+	if appliedOpts.Recursive {
 		delimiter = ""
 	}
 
-	query := &storage.Query{
+	it := b.bkt.Objects(ctx, &storage.Query{
 		Prefix:    dir,
 		Delimiter: delimiter,
-	}
-	err := query.SetAttrSelection([]string{"Name"})
-	if err != nil {
-		return err
-	}
-
-	it := b.bkt.Objects(ctx, query)
+	})
 	for {
 		select {
 		case <-ctx.Done():
@@ -219,10 +221,32 @@ func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error, opt
 		if err != nil {
 			return err
 		}
-		if err := f(attrs.Prefix + attrs.Name); err != nil {
+
+		objAttrs := objstore.IterObjectAttributes{Name: attrs.Prefix + attrs.Name}
+		if appliedOpts.LastModified {
+			objAttrs.SetLastModified(attrs.Updated)
+		}
+		if err := f(objAttrs); err != nil {
 			return err
 		}
 	}
+}
+
+// Iter calls f for each entry in the given directory. The argument to f is the full
+// object name including the prefix of the inspected directory.
+func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error, opts ...objstore.IterOption) error {
+	// Only include recursive option since attributes are not used in this method.
+	var filteredOpts []objstore.IterOption
+	for _, opt := range opts {
+		if opt.Type == objstore.Recursive {
+			filteredOpts = append(filteredOpts, opt)
+			break
+		}
+	}
+
+	return b.IterWithAttributes(ctx, dir, func(attrs objstore.IterObjectAttributes) error {
+		return f(attrs.Name)
+	}, filteredOpts...)
 }
 
 // Get returns a reader for the given object name.

--- a/providers/gcs/gcs.go
+++ b/providers/gcs/gcs.go
@@ -204,10 +204,20 @@ func (b *Bucket) IterWithAttributes(ctx context.Context, dir string, f func(attr
 		delimiter = ""
 	}
 
-	it := b.bkt.Objects(ctx, &storage.Query{
+	query := &storage.Query{
 		Prefix:    dir,
 		Delimiter: delimiter,
-	})
+	}
+	if appliedOpts.LastModified {
+		if err := query.SetAttrSelection([]string{"Name", "Updated"}); err != nil {
+			return err
+		}
+	} else {
+		if err := query.SetAttrSelection([]string{"Name"}); err != nil {
+			return err
+		}
+	}
+	it := b.bkt.Objects(ctx, query)
 	for {
 		select {
 		case <-ctx.Done():

--- a/testing.go
+++ b/testing.go
@@ -195,7 +195,7 @@ func AcceptanceTest(t *testing.T, bkt Bucket) {
 	testutil.Ok(t, bkt.Iter(ctx, "", func(fn string) error {
 		seen = append(seen, fn)
 		return nil
-	}, WithRecursiveIter))
+	}, WithRecursiveIter()))
 	expected = []string{"id1/obj_1.some", "id1/obj_2.some", "id1/obj_3.some", "id1/sub/subobj_1.some", "id1/sub/subobj_2.some", "id2/obj_4.some", "obj_5.some"}
 	sort.Strings(expected)
 	sort.Strings(seen)
@@ -214,7 +214,7 @@ func AcceptanceTest(t *testing.T, bkt Bucket) {
 	testutil.Ok(t, bkt.Iter(ctx, "id1/", func(fn string) error {
 		seen = append(seen, fn)
 		return nil
-	}, WithRecursiveIter))
+	}, WithRecursiveIter()))
 	testutil.Equals(t, []string{"id1/obj_1.some", "id1/obj_2.some", "id1/obj_3.some", "id1/sub/subobj_1.some", "id1/sub/subobj_2.some"}, seen)
 
 	// Can we iter over items from id1 dir?
@@ -230,7 +230,7 @@ func AcceptanceTest(t *testing.T, bkt Bucket) {
 	testutil.Ok(t, bkt.Iter(ctx, "id1", func(fn string) error {
 		seen = append(seen, fn)
 		return nil
-	}, WithRecursiveIter))
+	}, WithRecursiveIter()))
 	testutil.Equals(t, []string{"id1/obj_1.some", "id1/obj_2.some", "id1/obj_3.some", "id1/sub/subobj_1.some", "id1/sub/subobj_2.some"}, seen)
 
 	// Can we iter over items from not existing dir?
@@ -293,6 +293,15 @@ func (d *delayingBucket) Attributes(ctx context.Context, name string) (ObjectAtt
 func (d *delayingBucket) Iter(ctx context.Context, dir string, f func(string) error, options ...IterOption) error {
 	time.Sleep(d.delay)
 	return d.bkt.Iter(ctx, dir, f, options...)
+}
+
+func (d *delayingBucket) IterWithAttributes(ctx context.Context, dir string, f func(IterObjectAttributes) error, options ...IterOption) error {
+	time.Sleep(d.delay)
+	return d.bkt.IterWithAttributes(ctx, dir, f, options...)
+}
+
+func (d *delayingBucket) SupportedIterOptions() []IterOptionType {
+	return d.bkt.SupportedIterOptions()
 }
 
 func (d *delayingBucket) GetRange(ctx context.Context, name string, off, length int64) (io.ReadCloser, error) {

--- a/tracing/opentelemetry/opentelemetry.go
+++ b/tracing/opentelemetry/opentelemetry.go
@@ -36,6 +36,24 @@ func (t TracingBucket) Iter(ctx context.Context, dir string, f func(string) erro
 	return t.bkt.Iter(ctx, dir, f, options...)
 }
 
+func (t TracingBucket) IterWithAttributes(ctx context.Context, dir string, f func(attrs objstore.IterObjectAttributes) error, options ...objstore.IterOption) (err error) {
+	ctx, span := t.tracer.Start(ctx, "bucket_iter_with_attrs")
+	defer span.End()
+	span.SetAttributes(attribute.String("dir", dir))
+
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+		}
+	}()
+	return t.bkt.IterWithAttributes(ctx, dir, f, options...)
+}
+
+// SupportedIterOptions returns a list of supported IterOptions by the underlying provider.
+func (t TracingBucket) SupportedIterOptions() []objstore.IterOptionType {
+	return t.bkt.SupportedIterOptions()
+}
+
 func (t TracingBucket) Get(ctx context.Context, name string) (io.ReadCloser, error) {
 	ctx, span := t.tracer.Start(ctx, "bucket_get")
 	defer span.End()

--- a/tracing/opentracing/opentracing.go
+++ b/tracing/opentracing/opentracing.go
@@ -52,6 +52,18 @@ func (t TracingBucket) Iter(ctx context.Context, dir string, f func(string) erro
 	return
 }
 
+func (t TracingBucket) IterWithAttributes(ctx context.Context, dir string, f func(attrs objstore.IterObjectAttributes) error, options ...objstore.IterOption) (err error) {
+	doWithSpan(ctx, "bucket_iter_with_attrs", func(spanCtx context.Context, span opentracing.Span) {
+		span.LogKV("dir", dir)
+		err = t.bkt.IterWithAttributes(spanCtx, dir, f, options...)
+	})
+	return
+}
+
+func (t TracingBucket) SupportedIterOptions() []objstore.IterOptionType {
+	return t.bkt.SupportedIterOptions()
+}
+
 func (t TracingBucket) Get(ctx context.Context, name string) (io.ReadCloser, error) {
 	span, spanCtx := startSpan(ctx, "bucket_get")
 	span.LogKV("name", name)


### PR DESCRIPTION
Add support for IterWithAttributes

This commit adds support for an IterWithAttributes on the bucket client.
The method allows iterating through objects and getting multiple attributes
into the callback function, removing the need to do an Iter followed by Attrs.

For now, we only support getting the last updated time as an attribute, but the
implementation allows adding more in the future.

Not all buckets support this method. The client can check whether the bucket has
support by calling the SupportedIterOptions method on the client.

Co-authored-by: Ashwanth Goli <iamashwanth@gmail.com>
Co-authored-by: Filip Petkovski <filip.petkovsky@gmail.com>

Signed-off-by: Filip Petkovski <filip.petkovsky@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "s3:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos Objstore <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/objstore/pull/<PR-id>
    <Component> Component affected by your changes such as s3, azure, cos.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

* Add support for `IterWithAttributes`. 

## Verification

* Unit tests.
