### PR TITLE
Only register fetched_bytes metrics for Get/GetRange

### DIFF
--- a/objstore.go
+++ b/objstore.go
@@ -591,7 +591,6 @@ func wrapWithMetrics(b Bucket, metrics *Metrics) *metricBucket {
 		bkt.metrics.ops.WithLabelValues(op)
 		bkt.metrics.opsFailures.WithLabelValues(op)
 		bkt.metrics.opsDuration.WithLabelValues(op)
-		bkt.metrics.opsFetchedBytes.WithLabelValues(op)
 	}
 
 	// fetched bytes only relevant for get, getrange and upload
@@ -600,6 +599,7 @@ func wrapWithMetrics(b Bucket, metrics *Metrics) *metricBucket {
 		OpGetRange,
 		OpUpload,
 	} {
+		bkt.metrics.opsFetchedBytes.WithLabelValues(op)
 		bkt.metrics.opsTransferredBytes.WithLabelValues(op)
 	}
 	return bkt

--- a/objstore_test.go
+++ b/objstore_test.go
@@ -324,12 +324,8 @@ func TestDownloadUploadDirConcurrency(t *testing.T) {
 	testutil.Ok(t, promtest.GatherAndCompare(r, strings.NewReader(`
         # HELP objstore_bucket_operation_fetched_bytes_total Total number of bytes fetched from bucket, per operation.
         # TYPE objstore_bucket_operation_fetched_bytes_total counter
-        objstore_bucket_operation_fetched_bytes_total{bucket="",operation="attributes"} 0
-        objstore_bucket_operation_fetched_bytes_total{bucket="",operation="delete"} 0
-        objstore_bucket_operation_fetched_bytes_total{bucket="",operation="exists"} 0
         objstore_bucket_operation_fetched_bytes_total{bucket="",operation="get"} 1.048578e+06
         objstore_bucket_operation_fetched_bytes_total{bucket="",operation="get_range"} 0
-        objstore_bucket_operation_fetched_bytes_total{bucket="",operation="iter"} 0
         objstore_bucket_operation_fetched_bytes_total{bucket="",operation="upload"} 0
 		`), `objstore_bucket_operation_fetched_bytes_total`))
 


### PR DESCRIPTION
The other operations are not exposing the fetched bytes.
