### PR TITLE
GCS: use Query.SetAttrSelection when listing objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#64](https://github.com/thanos-io/objstore/pull/64) OCI: OKE Workload Identity support.
 - [#73](https://github.com/thanos-io/objstore/pull/73) Аdded file path to erros from DownloadFile
 - [#51](https://github.com/thanos-io/objstore/pull/51) Azure: Support using connection string authentication.
+- [#76](https://github.com/thanos-io/objstore/pull/76) GCS: Query for object names only in `Iter` to possibly improve performance when listing objects.
 
 ### Changed
 - [#38](https://github.com/thanos-io/objstore/pull/38) *: Upgrade minio-go version to `v7.0.45`.

--- a/providers/gcs/gcs.go
+++ b/providers/gcs/gcs.go
@@ -108,10 +108,16 @@ func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error, opt
 		delimiter = ""
 	}
 
-	it := b.bkt.Objects(ctx, &storage.Query{
+	query := &storage.Query{
 		Prefix:    dir,
 		Delimiter: delimiter,
-	})
+	}
+	err := query.SetAttrSelection([]string{"Name"})
+	if err != nil {
+		return err
+	}
+
+	it := b.bkt.Objects(ctx, query)
 	for {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "s3:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos Objstore <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/objstore/pull/<PR-id>
    <Component> Component affected by your changes such as s3, azure, cos.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
Uses [Query.SetAttrSelection](https://pkg.go.dev/cloud.google.com/go/storage#Query.SetAttrSelection) to only populate the `Name` field in `Iter` for GCS since it's the only object field used. It is suggested in the documentation near the bottom of this [section](https://pkg.go.dev/cloud.google.com/go/storage?utm_source=godoc#hdr-Listing_objects). In case it confuses anyone else besides me `Prefix` isn't an option available to set ([reference](https://github.com/googleapis/google-cloud-go/blob/134e37b184cb8fcec1c93a4cd53df3cf60280dc9/storage/storage.go#L1561)) and isn't affected. 

## Verification

<!-- How you tested it? How do you know it works? -->
Locally performed recursive and non-recursive listings both with this change and without against a development bucket. The listing results were identical. I did not attempt to measure a performance impact myself.

