### PR TITLE
Fix metricBucket losing object size in Upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#33](https://github.com/thanos-io/objstore/pull/33) Tracing: Add `ContextWithTracer()` to inject the tracer into the context.
 - [#34](https://github.com/thanos-io/objstore/pull/34) Fix ignored options when creating shared credential Azure client.
 - [#62](https://github.com/thanos-io/objstore/pull/62) S3: Fix ignored context cancellation in `Iter` method.
+- [#77](https://github.com/thanos-io/objstore/pull/77) Fix buckets wrapped with metrics from being unable to determine object sizes in `Upload`.
 
 ### Added
 - [#15](https://github.com/thanos-io/objstore/pull/15) Add Oracle Cloud Infrastructure Object Storage Bucket support.

--- a/objstore.go
+++ b/objstore.go
@@ -594,7 +594,7 @@ func (b *metricBucket) Upload(ctx context.Context, name string, r io.Reader) err
 	b.ops.WithLabelValues(op).Inc()
 
 	trc := newTimingReadCloser(
-		io.NopCloser(r),
+		NopCloserWithSize(r),
 		op,
 		b.opsDuration,
 		b.opsFailures,


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "s3:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos Objstore <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/objstore/pull/<PR-id>
    <Component> Component affected by your changes such as s3, azure, cos.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

In metricBucket's `Upload` the reader was being wrapped with `io.NopCloser`, but `newTimingReadCloser` will call `TryToGetSize` [here](https://github.com/thanos-io/objstore/blob/eb06103887ab787f47d08e8a2f100264087319d5/objstore.go#L671) and then get an error.

I noticed this because I saw this in a test's log message ([reference](https://github.com/grafana/mimir/actions/runs/6227135443/job/16905081839?pr=6061))
```
21:56:01 alertmanager-1: ts=2023-09-18T21:56:01.855369927Z caller=s3.go:487 level=warn msg="could not guess file size for multipart upload; upload might be not optimized" name=alertmanager/user-1/fullstate err="unsupported type of io.Reader: io.nopCloserWriterTo"
```
Introduced in https://github.com/thanos-io/objstore/pull/66#discussion_r1287041954

## Verification
Stepped through a throwaway test:
```go
b := WrapWithMetrics(NewInMemBucket(), prometheus.NewPedanticRegistry(), "a")
b.Upload(context.Background(), "test", bytes.NewReader([]byte{}))
```
<!-- How you tested it? How do you know it works? -->
