### PR TITLE
s3: Allow turning off checksums in S3 Puts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#73](https://github.com/thanos-io/objstore/pull/73) Аdded file path to erros from DownloadFile
 - [#51](https://github.com/thanos-io/objstore/pull/51) Azure: Support using connection string authentication.
 - [#76](https://github.com/thanos-io/objstore/pull/76) GCS: Query for object names only in `Iter` to possibly improve performance when listing objects.
+- [#85](https://github.com/thanos-io/objstore/pull/85) S3: Allow checksum algorithm to be configured
 
 ### Changed
 - [#38](https://github.com/thanos-io/objstore/pull/38) *: Upgrade minio-go version to `v7.0.45`.


### PR DESCRIPTION
https://github.com/thanos-io/thanos/pull/6746 bumped objstore, which bumped minio, which made Thanos incompatible with otherwise compliant S3 backends that do not support the x-amz-checksum header.


* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

- Add in a `PutWithMD5` (open to naming changes) config entry to the S3 bucket config that allows turning off this header so that Thanos supports these backends.

## Verification

Running this at Cloudflare on our [r2](https://developers.cloudflare.com/r2/) backed Thanos that doesn't support this header
