### PR TITLE
breaking :warning: GCS,S3,BOS: Remove thanos- prefix from the user agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,4 +44,5 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#65](https://github.com/thanos-io/objstore/pull/65) *: Upgrade minio-go version to `v7.0.61`.
 - [#70](https://github.com/thanos-io/objstore/pull/70) GCS: Update cloud.google.com/go/storage version to `v1.27.0`.
 - [#71](https://github.com/thanos-io/objstore/pull/71) Replace method `IsCustomerManagedKeyError` for a more generic `IsAccessDeniedErr` on the bucket interface.
+- [#88](https://github.com/thanos-io/objstore/pull/88) breaking :warning: GCS,S3,BOS: Remove thanos- prefix from the user agent
 ### Removed

--- a/providers/bos/bos.go
+++ b/providers/bos/bos.go
@@ -89,7 +89,7 @@ func NewBucketWithConfig(logger log.Logger, config Config, component string) (*B
 		return nil, errors.Wrap(err, "creating BOS client")
 	}
 
-	client.Config.UserAgent = fmt.Sprintf("thanos-%s", component)
+	client.Config.UserAgent = component
 
 	bkt := &Bucket{
 		logger: logger,

--- a/providers/gcs/gcs.go
+++ b/providers/gcs/gcs.go
@@ -72,7 +72,7 @@ func NewBucketWithConfig(ctx context.Context, logger log.Logger, gc Config, comp
 	}
 
 	opts = append(opts,
-		option.WithUserAgent(fmt.Sprintf("thanos-%s/%s (%s)", component, version.Version, runtime.Version())),
+		option.WithUserAgent(fmt.Sprintf("%s/%s (%s)", component, version.Version, runtime.Version())),
 	)
 
 	gcsClient, err := storage.NewClient(ctx, opts...)

--- a/providers/s3/s3.go
+++ b/providers/s3/s3.go
@@ -272,7 +272,7 @@ func NewBucketWithConfig(logger log.Logger, config Config, component string) (*B
 	if err != nil {
 		return nil, errors.Wrap(err, "initialize s3 client")
 	}
-	client.SetAppInfo(fmt.Sprintf("thanos-%s", component), fmt.Sprintf("%s (%s)", version.Version, runtime.Version()))
+	client.SetAppInfo(component, fmt.Sprintf("%s (%s)", version.Version, runtime.Version()))
 
 	var sse encrypt.ServerSide
 	if config.SSEConfig.Type != "" {


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "s3:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos Objstore <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/objstore/pull/<PR-id>
    <Component> Component affected by your changes such as s3, azure, cos.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Remove `thanos-` prefix from the user agent.

This change will impact users who, for example, are operating MinIO and are using the user agent there.

If necessary, re-create a pull request for each provider.

Close https://github.com/thanos-io/objstore/issues/87

## Verification

<!-- How you tested it? How do you know it works? -->
