### PR TITLE
Enable using gRPC client for GCS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#51](https://github.com/thanos-io/objstore/pull/51) Azure: Support using connection string authentication.
 - [#76](https://github.com/thanos-io/objstore/pull/76) GCS: Query for object names only in `Iter` to possibly improve performance when listing objects.
 - [#85](https://github.com/thanos-io/objstore/pull/85) S3: Allow checksum algorithm to be configured
+- [#92](https://github.com/thanos-io/objstore/pull/92) GCS: Allow using a gRPC client.
 
 ### Changed
 - [#38](https://github.com/thanos-io/objstore/pull/38) *: Upgrade minio-go version to `v7.0.45`.

--- a/README.md
+++ b/README.md
@@ -352,6 +352,8 @@ type: GCS
 config:
   bucket: ""
   service_account: ""
+  use_grpc: false
+  grpc_conn_pool_size: 0
 prefix: ""
 ```
 

--- a/providers/gcs/gcs.go
+++ b/providers/gcs/gcs.go
@@ -32,10 +32,14 @@ const DirDelim = "/"
 
 // Config stores the configuration for gcs bucket.
 type Config struct {
-	Bucket           string `yaml:"bucket"`
-	ServiceAccount   string `yaml:"service_account"`
-	UseGRPC          bool   `yaml:"use_grpc"`
-	GRPCConnPoolSize int    `yaml:"grpc_conn_pool_size"`
+	Bucket         string `yaml:"bucket"`
+	ServiceAccount string `yaml:"service_account"`
+	UseGRPC        bool   `yaml:"use_grpc"`
+	// GRPCConnPoolSize controls the size of the gRPC connection pool and should only be used
+	// when direct path is not enabled.
+	// See https://pkg.go.dev/cloud.google.com/go/storage#hdr-Experimental_gRPC_API for more details
+	// on how to enable direct path.
+	GRPCConnPoolSize int `yaml:"grpc_conn_pool_size"`
 }
 
 // Bucket implements the store.Bucket and shipper.Bucket interfaces against GCS.


### PR DESCRIPTION
GCP has an experimental feature which allows using gRPC when talking to GCS. For the time being, it requires buckets to be explicitly added to an allowlist, but eventually the feature will become GA.

This commit allows using a gRPC client when creating a GCS bucket by toggling a boolean flag in the bucket config.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "s3:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos Objstore <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/objstore/pull/<PR-id>
    <Component> Component affected by your changes such as s3, azure, cos.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

* Allow using gRPC for GCS buckets.

## Verification

<!-- How you tested it? How do you know it works? -->
