### PR TITLE
Allow timingReadCloser to be seeker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#76](https://github.com/thanos-io/objstore/pull/76) GCS: Query for object names only in `Iter` to possibly improve performance when listing objects.
 - [#85](https://github.com/thanos-io/objstore/pull/85) S3: Allow checksum algorithm to be configured
 - [#92](https://github.com/thanos-io/objstore/pull/92) GCS: Allow using a gRPC client.
+- [#94](https://github.com/thanos-io/objstore/pull/94) Allow timingReadCloser to be seeker 
 
 ### Changed
 - [#38](https://github.com/thanos-io/objstore/pull/38) *: Upgrade minio-go version to `v7.0.45`.

--- a/objstore_test.go
+++ b/objstore_test.go
@@ -232,6 +232,35 @@ func TestTimingTracingReader(t *testing.T) {
 	testutil.Equals(t, int64(11), size)
 }
 
+func TestTimingTracingReaderSeeker(t *testing.T) {
+	m := WrapWithMetrics(NewInMemBucket(), nil, "")
+	r := bytes.NewReader([]byte("hello world"))
+
+	tr := nopSeekerCloserWithSize(r).(io.ReadCloser)
+	tr = newTimingReadCloser(tr, "", m.opsDuration, m.opsFailures, func(err error) bool {
+		return false
+	}, m.opsFetchedBytes, m.opsTransferredBytes)
+
+	size, err := TryToGetSize(tr)
+
+	testutil.Ok(t, err)
+	testutil.Equals(t, int64(11), size)
+
+	smallBuf := make([]byte, 4)
+	n, err := io.ReadFull(tr, smallBuf)
+	testutil.Ok(t, err)
+	testutil.Equals(t, 4, n)
+
+	// Verify that size is still the same, after reading 4 bytes.
+	size, err = TryToGetSize(tr)
+
+	testutil.Ok(t, err)
+	testutil.Equals(t, int64(11), size)
+
+	_, ok := tr.(io.Seeker)
+	testutil.Equals(t, true, ok)
+}
+
 func TestDownloadDir_CleanUp(t *testing.T) {
 	b := unreliableBucket{
 		Bucket:  NewInMemBucket(),
@@ -263,4 +292,17 @@ func (b unreliableBucket) Get(ctx context.Context, name string) (io.ReadCloser, 
 		return nil, errors.Errorf("some error message")
 	}
 	return b.Bucket.Get(ctx, name)
+}
+
+type nopSeekerCloserWithObjectSize struct{ io.Reader }
+
+func (n nopSeekerCloserWithObjectSize) Seek(offset int64, whence int) (int64, error) {
+	return 0, nil
+}
+
+func (nopSeekerCloserWithObjectSize) Close() error                 { return nil }
+func (n nopSeekerCloserWithObjectSize) ObjectSize() (int64, error) { return TryToGetSize(n.Reader) }
+
+func nopSeekerCloserWithSize(r io.Reader) io.ReadSeekCloser {
+	return nopSeekerCloserWithObjectSize{r}
 }


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "s3:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos Objstore <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/objstore/pull/<PR-id>
    <Component> Component affected by your changes such as s3, azure, cos.
-->

* [X] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
Cortex uses objstore to update blocks to s3. Cortex had added a retry functionality using seeker objects.
https://github.com/cortexproject/cortex/blob/master/pkg/storage/bucket/s3/bucket_client.go#L176-L191
It checks if an object is seeker and if so it allow it to retry. 

It also wrap the bucket store with metrics
https://github.com/cortexproject/cortex/blob/master/pkg/storage/bucket/client.go#L145

With the new timing metrics, ojbstore now override the object and thus change it to always be io.ReadCloser which is what the implementation requires, but it does not allow cortex to retry request anymore.
The change allow it to continue using a seeker object if the original object was seekable.

## Verification
Added unit tests to verify the functionality still works.