### PR TITLE
azure: fix when endpoint is empty

### DIFF
--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -101,6 +101,10 @@ func (conf *Config) validate() error {
 		errMsg = append(errMsg, "The value of max_retry_requests must be greater than or equal to 0 in the config file")
 	}
 
+	if conf.Endpoint == "" {
+		errMsg = append(errMsg, "The value of endpoint is required but not configured")
+	}
+
 	if len(errMsg) > 0 {
 		return errors.New(strings.Join(errMsg, ", "))
 	}


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Check if endpoint provided is empty in while validating the configuration

