### PR TITLE
Fix s3 upload performance regression

### DIFF
--- a/objstore.go
+++ b/objstore.go
@@ -232,19 +232,6 @@ func NopCloserWithSize(r io.Reader) io.ReadCloser {
 	return nopCloserWithObjectSize{r}
 }
 
-type nopSeekerCloserWithObjectSize struct{ io.Reader }
-
-func (nopSeekerCloserWithObjectSize) Close() error                 { return nil }
-func (n nopSeekerCloserWithObjectSize) ObjectSize() (int64, error) { return TryToGetSize(n.Reader) }
-
-func (n nopSeekerCloserWithObjectSize) Seek(offset int64, whence int) (int64, error) {
-	return n.Reader.(io.Seeker).Seek(offset, whence)
-}
-
-func nopSeekerCloserWithSize(r io.Reader) io.ReadSeekCloser {
-	return nopSeekerCloserWithObjectSize{r}
-}
-
 // UploadDir uploads all files in srcdir to the bucket with into a top-level directory
 // named dstdir. It is a caller responsibility to clean partial upload in case of failure.
 func UploadDir(ctx context.Context, logger log.Logger, bkt Bucket, srcdir, dstdir string, options ...UploadOption) error {
@@ -555,7 +542,7 @@ func (b *metricBucket) Get(ctx context.Context, name string) (io.ReadCloser, err
 		}
 		return nil, err
 	}
-	return newTimingReadCloser(
+	return newTimingReader(
 		rc,
 		op,
 		b.opsDuration,
@@ -577,7 +564,7 @@ func (b *metricBucket) GetRange(ctx context.Context, name string, off, length in
 		}
 		return nil, err
 	}
-	return newTimingReadCloser(
+	return newTimingReader(
 		rc,
 		op,
 		b.opsDuration,
@@ -608,16 +595,8 @@ func (b *metricBucket) Upload(ctx context.Context, name string, r io.Reader) err
 	const op = OpUpload
 	b.ops.WithLabelValues(op).Inc()
 
-	_, ok := r.(io.Seeker)
-	var nopR io.ReadCloser
-	if ok {
-		nopR = nopSeekerCloserWithSize(r)
-	} else {
-		nopR = NopCloserWithSize(r)
-	}
-
-	trc := newTimingReadCloser(
-		nopR,
+	trc := newTimingReader(
+		r,
 		op,
 		b.opsDuration,
 		b.opsFailures,
@@ -670,12 +649,8 @@ func (b *metricBucket) Name() string {
 	return b.bkt.Name()
 }
 
-type timingReadSeekCloser struct {
-	timingReadCloser
-}
-
-type timingReadCloser struct {
-	io.ReadCloser
+type timingReader struct {
+	io.Reader
 	objSize    int64
 	objSizeErr error
 
@@ -691,14 +666,14 @@ type timingReadCloser struct {
 	transferredBytes  *prometheus.HistogramVec
 }
 
-func newTimingReadCloser(rc io.ReadCloser, op string, dur *prometheus.HistogramVec, failed *prometheus.CounterVec, isFailureExpected IsOpFailureExpectedFunc, fetchedBytes *prometheus.CounterVec, transferredBytes *prometheus.HistogramVec) io.ReadCloser {
+func newTimingReader(r io.Reader, op string, dur *prometheus.HistogramVec, failed *prometheus.CounterVec, isFailureExpected IsOpFailureExpectedFunc, fetchedBytes *prometheus.CounterVec, transferredBytes *prometheus.HistogramVec) io.ReadCloser {
 	// Initialize the metrics with 0.
 	dur.WithLabelValues(op)
 	failed.WithLabelValues(op)
-	objSize, objSizeErr := TryToGetSize(rc)
+	objSize, objSizeErr := TryToGetSize(r)
 
-	trc := timingReadCloser{
-		ReadCloser:        rc,
+	trc := timingReader{
+		Reader:            r,
 		objSize:           objSize,
 		objSizeErr:        objSizeErr,
 		start:             time.Now(),
@@ -711,50 +686,79 @@ func newTimingReadCloser(rc io.ReadCloser, op string, dur *prometheus.HistogramV
 		readBytes:         0,
 	}
 
-	_, ok := rc.(io.Seeker)
-	if ok {
-		return &timingReadSeekCloser{
-			timingReadCloser: trc,
-		}
+	_, isSeeker := r.(io.Seeker)
+	_, isReaderAt := r.(io.ReaderAt)
+
+	if isSeeker && isReaderAt {
+		// The assumption is that in most cases when io.ReaderAt() is implemented then
+		// io.Seeker is implemented too (e.g. os.File).
+		return &timingReaderSeekerReaderAt{timingReaderSeeker: timingReaderSeeker{timingReader: trc}}
+	}
+	if isSeeker {
+		return &timingReaderSeeker{timingReader: trc}
 	}
 
 	return &trc
 }
 
-func (t *timingReadCloser) ObjectSize() (int64, error) {
-	return t.objSize, t.objSizeErr
+func (r *timingReader) ObjectSize() (int64, error) {
+	return r.objSize, r.objSizeErr
 }
 
-func (rc *timingReadCloser) Close() error {
-	err := rc.ReadCloser.Close()
-	if !rc.alreadyGotErr && err != nil {
-		rc.failed.WithLabelValues(rc.op).Inc()
-	}
-	if !rc.alreadyGotErr && err == nil {
-		rc.duration.WithLabelValues(rc.op).Observe(time.Since(rc.start).Seconds())
-		rc.transferredBytes.WithLabelValues(rc.op).Observe(float64(rc.readBytes))
-		rc.alreadyGotErr = true
-	}
-	return err
-}
+func (r *timingReader) Close() error {
+	var closeErr error
 
-func (rc *timingReadCloser) Read(b []byte) (n int, err error) {
-	n, err = rc.ReadCloser.Read(b)
-	if rc.fetchedBytes != nil {
-		rc.fetchedBytes.WithLabelValues(rc.op).Add(float64(n))
-	}
+	// Call the wrapped reader if it implements Close().
+	if closer, ok := r.Reader.(io.Closer); ok {
+		closeErr = closer.Close()
 
-	rc.readBytes += int64(n)
-	// Report metric just once.
-	if !rc.alreadyGotErr && err != nil && err != io.EOF {
-		if !rc.isFailureExpected(err) {
-			rc.failed.WithLabelValues(rc.op).Inc()
+		if !r.alreadyGotErr && closeErr != nil {
+			r.failed.WithLabelValues(r.op).Inc()
+			r.alreadyGotErr = true
 		}
-		rc.alreadyGotErr = true
+	}
+
+	// Track duration and transferred bytes only if no error occurred.
+	if !r.alreadyGotErr {
+		r.duration.WithLabelValues(r.op).Observe(time.Since(r.start).Seconds())
+		r.transferredBytes.WithLabelValues(r.op).Observe(float64(r.readBytes))
+
+		// Trick to tracking metrics multiple times in case Close() gets called again.
+		r.alreadyGotErr = true
+	}
+
+	return closeErr
+}
+
+func (r *timingReader) Read(b []byte) (n int, err error) {
+	n, err = r.Reader.Read(b)
+	if r.fetchedBytes != nil {
+		r.fetchedBytes.WithLabelValues(r.op).Add(float64(n))
+	}
+
+	r.readBytes += int64(n)
+	// Report metric just once.
+	if !r.alreadyGotErr && err != nil && err != io.EOF {
+		if !r.isFailureExpected(err) {
+			r.failed.WithLabelValues(r.op).Inc()
+		}
+		r.alreadyGotErr = true
 	}
 	return n, err
 }
 
-func (rsc *timingReadSeekCloser) Seek(offset int64, whence int) (int64, error) {
-	return (rsc.ReadCloser).(io.Seeker).Seek(offset, whence)
+type timingReaderSeeker struct {
+	timingReader
+}
+
+func (rsc *timingReaderSeeker) Seek(offset int64, whence int) (int64, error) {
+	return (rsc.Reader).(io.Seeker).Seek(offset, whence)
+}
+
+type timingReaderSeekerReaderAt struct {
+	timingReaderSeeker
+}
+
+func (rsc *timingReaderSeekerReaderAt) ReadAt(p []byte, off int64) (int, error) {
+	return (rsc.Reader).(io.ReaderAt).ReadAt(p, off)
 }

--- a/objstore_test.go
+++ b/objstore_test.go
@@ -81,6 +81,208 @@ func TestMetricBucket_Multiple_Clients(t *testing.T) {
 	WrapWithMetrics(NewInMemBucket(), reg, "def")
 }
 
+func TestMetricBucket_UploadShouldPreserveReaderFeatures(t *testing.T) {
+	tests := map[string]struct {
+		reader             io.Reader
+		expectedIsSeeker   bool
+		expectedIsReaderAt bool
+	}{
+		"bytes.Reader": {
+			reader:             bytes.NewReader([]byte("1")),
+			expectedIsSeeker:   true,
+			expectedIsReaderAt: true,
+		},
+		"bytes.Buffer": {
+			reader:             bytes.NewBuffer([]byte("1")),
+			expectedIsSeeker:   false,
+			expectedIsReaderAt: false,
+		},
+		"os.File": {
+			reader: func() io.Reader {
+				// Create a test file.
+				testFilepath := filepath.Join(t.TempDir(), "test")
+				testutil.Ok(t, os.WriteFile(testFilepath, []byte("test"), os.ModePerm))
+
+				// Open the file (it will be used as io.Reader).
+				file, err := os.Open(testFilepath)
+				testutil.Ok(t, err)
+				t.Cleanup(func() {
+					testutil.Ok(t, file.Close())
+				})
+
+				return file
+			}(),
+			expectedIsSeeker:   true,
+			expectedIsReaderAt: true,
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			var uploadReader io.Reader
+
+			m := &mockBucket{
+				Bucket: WrapWithMetrics(NewInMemBucket(), nil, ""),
+				upload: func(ctx context.Context, name string, r io.Reader) error {
+					uploadReader = r
+					return nil
+				},
+			}
+
+			testutil.Ok(t, m.Upload(context.Background(), "dir/obj1", testData.reader))
+
+			_, isSeeker := uploadReader.(io.Seeker)
+			testutil.Equals(t, testData.expectedIsSeeker, isSeeker)
+
+			_, isReaderAt := uploadReader.(io.ReaderAt)
+			testutil.Equals(t, testData.expectedIsReaderAt, isReaderAt)
+		})
+	}
+}
+
+func TestMetricBucket_ReaderClose(t *testing.T) {
+	const objPath = "dir/obj1"
+
+	t.Run("Upload() should not close the input Reader", func(t *testing.T) {
+		closeCalled := false
+
+		reader := &mockReader{
+			Reader: bytes.NewBuffer([]byte("test")),
+			close: func() error {
+				closeCalled = true
+				return nil
+			},
+		}
+
+		bucket := WrapWithMetrics(NewInMemBucket(), nil, "")
+		testutil.Ok(t, bucket.Upload(context.Background(), objPath, reader))
+
+		// Should not call Close() on the reader.
+		testutil.Assert(t, !closeCalled)
+
+		// An explicit call to Close() should close it.
+		testutil.Ok(t, reader.Close())
+		testutil.Assert(t, closeCalled)
+
+		testutil.Equals(t, float64(1), promtest.ToFloat64(bucket.ops.WithLabelValues(OpUpload)))
+		testutil.Equals(t, float64(0), promtest.ToFloat64(bucket.opsFailures.WithLabelValues(OpUpload)))
+	})
+
+	t.Run("Get() should return a wrapper io.ReadCloser that correctly Close the wrapped one", func(t *testing.T) {
+		closeCalled := false
+
+		origReader := &mockReader{
+			Reader: bytes.NewBuffer([]byte("test")),
+			close: func() error {
+				closeCalled = true
+				return nil
+			},
+		}
+
+		bucket := WrapWithMetrics(&mockBucket{
+			get: func(_ context.Context, _ string) (io.ReadCloser, error) {
+				return origReader, nil
+			},
+		}, nil, "")
+
+		wrappedReader, err := bucket.Get(context.Background(), objPath)
+		testutil.Ok(t, err)
+		testutil.Assert(t, origReader != wrappedReader)
+
+		// Calling Close() to the wrappedReader should close origReader.
+		testutil.Assert(t, !closeCalled)
+		testutil.Ok(t, wrappedReader.Close())
+		testutil.Assert(t, closeCalled)
+
+		testutil.Equals(t, float64(1), promtest.ToFloat64(bucket.ops.WithLabelValues(OpGet)))
+		testutil.Equals(t, float64(0), promtest.ToFloat64(bucket.opsFailures.WithLabelValues(OpGet)))
+	})
+
+	t.Run("GetRange() should return a wrapper io.ReadCloser that correctly Close the wrapped one", func(t *testing.T) {
+		closeCalled := false
+
+		origReader := &mockReader{
+			Reader: bytes.NewBuffer([]byte("test")),
+			close: func() error {
+				closeCalled = true
+				return nil
+			},
+		}
+
+		bucket := WrapWithMetrics(&mockBucket{
+			getRange: func(_ context.Context, _ string, _, _ int64) (io.ReadCloser, error) {
+				return origReader, nil
+			},
+		}, nil, "")
+
+		wrappedReader, err := bucket.GetRange(context.Background(), objPath, 0, 1)
+		testutil.Ok(t, err)
+		testutil.Assert(t, origReader != wrappedReader)
+
+		// Calling Close() to the wrappedReader should close origReader.
+		testutil.Assert(t, !closeCalled)
+		testutil.Ok(t, wrappedReader.Close())
+		testutil.Assert(t, closeCalled)
+
+		testutil.Equals(t, float64(1), promtest.ToFloat64(bucket.ops.WithLabelValues(OpGetRange)))
+		testutil.Equals(t, float64(0), promtest.ToFloat64(bucket.opsFailures.WithLabelValues(OpGetRange)))
+	})
+}
+
+func TestMetricBucket_ReaderCloseError(t *testing.T) {
+	origReader := &mockReader{
+		Reader: bytes.NewBuffer([]byte("test")),
+		close: func() error {
+			return errors.New("mocked error")
+		},
+	}
+
+	t.Run("Get() should track failure if reader Close() returns error", func(t *testing.T) {
+		bucket := WrapWithMetrics(&mockBucket{
+			get: func(ctx context.Context, name string) (io.ReadCloser, error) {
+				return origReader, nil
+			},
+		}, nil, "")
+
+		testutil.NotOk(t, bucket.Upload(context.Background(), "test", origReader))
+
+		testutil.Equals(t, float64(1), promtest.ToFloat64(bucket.ops.WithLabelValues(OpUpload)))
+		testutil.Equals(t, float64(1), promtest.ToFloat64(bucket.opsFailures.WithLabelValues(OpUpload)))
+	})
+
+	t.Run("Get() should track failure if reader Close() returns error", func(t *testing.T) {
+		bucket := WrapWithMetrics(&mockBucket{
+			get: func(ctx context.Context, name string) (io.ReadCloser, error) {
+				return origReader, nil
+			},
+		}, nil, "")
+
+		reader, err := bucket.Get(context.Background(), "test")
+		testutil.Ok(t, err)
+		testutil.NotOk(t, reader.Close())
+		testutil.NotOk(t, reader.Close()) // Called twice to ensure metrics are not tracked twice.
+
+		testutil.Equals(t, float64(1), promtest.ToFloat64(bucket.ops.WithLabelValues(OpGet)))
+		testutil.Equals(t, float64(1), promtest.ToFloat64(bucket.opsFailures.WithLabelValues(OpGet)))
+	})
+
+	t.Run("GetRange() should track failure if reader Close() returns error", func(t *testing.T) {
+		bucket := WrapWithMetrics(&mockBucket{
+			getRange: func(ctx context.Context, name string, off, length int64) (io.ReadCloser, error) {
+				return origReader, nil
+			},
+		}, nil, "")
+
+		reader, err := bucket.GetRange(context.Background(), "test", 0, 1)
+		testutil.Ok(t, err)
+		testutil.NotOk(t, reader.Close())
+		testutil.NotOk(t, reader.Close()) // Called twice to ensure metrics are not tracked twice.
+
+		testutil.Equals(t, float64(1), promtest.ToFloat64(bucket.ops.WithLabelValues(OpGetRange)))
+		testutil.Equals(t, float64(1), promtest.ToFloat64(bucket.opsFailures.WithLabelValues(OpGetRange)))
+	})
+}
+
 func TestDownloadUploadDirConcurrency(t *testing.T) {
 	r := prometheus.NewRegistry()
 	m := WrapWithMetrics(NewInMemBucket(), r, "")
@@ -263,127 +465,6 @@ func TestTimingReader_ShouldCorrectlyWrapFile(t *testing.T) {
 	testutil.Assert(t, isReaderAt)
 }
 
-func TestWrapWithMetrics_UploadShouldPreserveReaderFeatures(t *testing.T) {
-	tests := map[string]struct {
-		reader             io.Reader
-		expectedIsSeeker   bool
-		expectedIsReaderAt bool
-	}{
-		"bytes.Reader": {
-			reader:             bytes.NewReader([]byte("1")),
-			expectedIsSeeker:   true,
-			expectedIsReaderAt: true,
-		},
-		"bytes.Buffer": {
-			reader:             bytes.NewBuffer([]byte("1")),
-			expectedIsSeeker:   false,
-			expectedIsReaderAt: false,
-		},
-		"os.File": {
-			reader: func() io.Reader {
-				// Create a test file.
-				testFilepath := filepath.Join(t.TempDir(), "test")
-				testutil.Ok(t, os.WriteFile(testFilepath, []byte("test"), os.ModePerm))
-
-				// Open the file (it will be used as io.Reader).
-				file, err := os.Open(testFilepath)
-				testutil.Ok(t, err)
-				t.Cleanup(func() {
-					testutil.Ok(t, file.Close())
-				})
-
-				return file
-			}(),
-			expectedIsSeeker:   true,
-			expectedIsReaderAt: true,
-		},
-	}
-
-	for testName, testData := range tests {
-		t.Run(testName, func(t *testing.T) {
-			var uploadReader io.Reader
-
-			m := &testBucket{
-				Bucket: WrapWithMetrics(NewInMemBucket(), nil, ""),
-				upload: func(ctx context.Context, name string, r io.Reader) error {
-					uploadReader = r
-					return nil
-				},
-			}
-
-			testutil.Ok(t, m.Upload(context.Background(), "dir/obj1", testData.reader))
-
-			_, isSeeker := uploadReader.(io.Seeker)
-			testutil.Equals(t, testData.expectedIsSeeker, isSeeker)
-
-			_, isReaderAt := uploadReader.(io.ReaderAt)
-			testutil.Equals(t, testData.expectedIsReaderAt, isReaderAt)
-		})
-	}
-}
-
-func TestWrapWithMetrics_CloseReader(t *testing.T) {
-	const objPath = "dir/obj1"
-
-	t.Run("Upload() should not close the input Reader", func(t *testing.T) {
-		reader := &closeTrackerReader{
-			Reader: bytes.NewBuffer([]byte("test")),
-		}
-
-		bucket := WrapWithMetrics(NewInMemBucket(), nil, "")
-		testutil.Ok(t, bucket.Upload(context.Background(), objPath, reader))
-
-		// Should not call Close() on the reader.
-		testutil.Assert(t, !reader.closeCalled)
-
-		// An explicit call to Close() should close it.
-		testutil.Ok(t, reader.Close())
-		testutil.Assert(t, reader.closeCalled)
-	})
-
-	t.Run("Get() should return a wrapper io.ReadCloser that correctly Close the wrapped one", func(t *testing.T) {
-		origReader := &closeTrackerReader{
-			Reader: bytes.NewBuffer([]byte("test")),
-		}
-
-		bucket := WrapWithMetrics(&testBucket{
-			get: func(_ context.Context, _ string) (io.ReadCloser, error) {
-				return origReader, nil
-			},
-		}, nil, "")
-
-		wrappedReader, err := bucket.Get(context.Background(), objPath)
-		testutil.Ok(t, err)
-		testutil.Assert(t, origReader != wrappedReader)
-
-		// Calling Close() to the wrappedReader should close origReader.
-		testutil.Assert(t, !origReader.closeCalled)
-		testutil.Ok(t, wrappedReader.Close())
-		testutil.Assert(t, origReader.closeCalled)
-	})
-
-	t.Run("GetRange() should return a wrapper io.ReadCloser that correctly Close the wrapped one", func(t *testing.T) {
-		origReader := &closeTrackerReader{
-			Reader: bytes.NewBuffer([]byte("test")),
-		}
-
-		bucket := WrapWithMetrics(&testBucket{
-			getRange: func(_ context.Context, _ string, _, _ int64) (io.ReadCloser, error) {
-				return origReader, nil
-			},
-		}, nil, "")
-
-		wrappedReader, err := bucket.GetRange(context.Background(), objPath, 0, 1)
-		testutil.Ok(t, err)
-		testutil.Assert(t, origReader != wrappedReader)
-
-		// Calling Close() to the wrappedReader should close origReader.
-		testutil.Assert(t, !origReader.closeCalled)
-		testutil.Ok(t, wrappedReader.Close())
-		testutil.Assert(t, origReader.closeCalled)
-	})
-}
-
 func TestDownloadDir_CleanUp(t *testing.T) {
 	b := unreliableBucket{
 		Bucket:  NewInMemBucket(),
@@ -417,19 +498,22 @@ func (b unreliableBucket) Get(ctx context.Context, name string) (io.ReadCloser, 
 	return b.Bucket.Get(ctx, name)
 }
 
-// closeTrackerReader is a io.ReadCloser which keeps track whether Close() has been called.
-type closeTrackerReader struct {
+// mockReader implements io.ReadCloser and allows to mock the functions.
+type mockReader struct {
 	io.Reader
-	closeCalled bool
+
+	close func() error
 }
 
-func (r *closeTrackerReader) Close() error {
-	r.closeCalled = true
+func (r *mockReader) Close() error {
+	if r.close != nil {
+		return r.close()
+	}
 	return nil
 }
 
-// testBucket implements Bucket and allows to customize the functions.
-type testBucket struct {
+// mockBucket implements Bucket and allows to mock the functions.
+type mockBucket struct {
 	Bucket
 
 	upload   func(ctx context.Context, name string, r io.Reader) error
@@ -437,21 +521,21 @@ type testBucket struct {
 	getRange func(ctx context.Context, name string, off, length int64) (io.ReadCloser, error)
 }
 
-func (b *testBucket) Upload(ctx context.Context, name string, r io.Reader) error {
+func (b *mockBucket) Upload(ctx context.Context, name string, r io.Reader) error {
 	if b.upload != nil {
 		return b.upload(ctx, name, r)
 	}
 	return errors.New("Upload has not been mocked")
 }
 
-func (b *testBucket) Get(ctx context.Context, name string) (io.ReadCloser, error) {
+func (b *mockBucket) Get(ctx context.Context, name string) (io.ReadCloser, error) {
 	if b.get != nil {
 		return b.get(ctx, name)
 	}
 	return nil, errors.New("Get has not been mocked")
 }
 
-func (b *testBucket) GetRange(ctx context.Context, name string, off, length int64) (io.ReadCloser, error) {
+func (b *mockBucket) GetRange(ctx context.Context, name string, off, length int64) (io.ReadCloser, error) {
 	if b.getRange != nil {
 		return b.getRange(ctx, name, off, length)
 	}


### PR DESCRIPTION
## The symptom

The PR https://github.com/thanos-io/objstore/pull/66 introduced a regression in the S3 upload performance. After that commit, S3 uploaded are significantly slower. Here you can see how the upload latency changed for one of our Grafana Mimir clusters running in AWS:

![Screenshot 2024-01-26 at 14 46 33](https://github.com/thanos-io/objstore/assets/1701904/650348ba-7cc2-4894-84fc-5f18126a7556)

_Change deployed to prod on 10/06, where the latency increase. Since the upload performance in Mimir is not critical (e.g. doesn't affect neither read and write path latency), it was undetected for quite some time. Until today._

## The cause

Why the regression? Minio has some optimizations when the reader implements `io.ReaderAt` because it can leverage on `.ReadAt()`. We're used to call `Upload()` with `os.File` as a reader (I think Thanos does the same). After https://github.com/thanos-io/objstore/pull/66 wrapped the reader with the timing reader, which doesn't implement `io.ReaderAt` and so Minio couldn't optimize the upload anymore.

## The fix

In this PR I propose a fix to the issue, introducing `timingReaderSeekerReaderAt` which embeds `timingReaderSeeker`, which in turn embeds `timingReader`.

To simplify the code, I've removed the usage of `nopSeekerCloserWithSize()` and `NopCloserWithSize()` in the `Upload` and pushed down to `timingReader` whether we want it to `Close()` the wrapped reader or not. The renaming from `timingReadCloser` to `timingReader` follows this change, given it takes in input `io.Reader`.

## Manual test

I've manually that this PR fixes the upload speed regression, running a test in AWS which uploads 1GB object to S3 multiple times.

#### Before this PR

S3 bucket **not** wrapped with metrics:

```
With metrics: false Elapsed: 2.262466521s
With metrics: false Elapsed: 2.328912616s
With metrics: false Elapsed: 2.312762143s
```

S3 bucket wrapped with metrics (see higher latency):

```
With metrics: true Elapsed: 9.590695888s
With metrics: true Elapsed: 8.402357109s
With metrics: true Elapsed: 7.858041235s
```

#### After this PR

S3 bucket **not** wrapped with metrics:

```
With metrics: false Elapsed: 2.767424849s
With metrics: false Elapsed: 2.066829353s
With metrics: false Elapsed: 2.114329674s
```

S3 bucket wrapped with metrics (see **no** higher latency):

```
With metrics: true Elapsed: 2.728111635s
With metrics: true Elapsed: 2.216537896s
With metrics: true Elapsed: 2.392596594s
```