### PR TITLE
Metric bucket should not return error when error is expected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,4 +68,6 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#71](https://github.com/thanos-io/objstore/pull/71) Replace method `IsCustomerManagedKeyError` for a more generic `IsAccessDeniedErr` on the bucket interface.
 - [#89](https://github.com/thanos-io/objstore/pull/89) GCS: Upgrade cloud.google.com/go/storage version to `v1.35.1`.
 - [#123](https://github.com/thanos-io/objstore/pull/123) *: Upgrade minio-go version to `v7.0.71`.
+- [#103](https://github.com/thanos-io/objstore/pull/103) *: Don't return error in metric bucket if the error is expected.
+
 ### Removed

--- a/objstore.go
+++ b/objstore.go
@@ -638,7 +638,6 @@ func (b *metricBucket) Iter(ctx context.Context, dir string, f func(string) erro
 		} else if ctx.Err() != context.Canceled {
 			b.metrics.opsFailures.WithLabelValues(op).Inc()
 		}
-		return err
 	}
 	return err
 }
@@ -652,7 +651,9 @@ func (b *metricBucket) IterWithAttributes(ctx context.Context, dir string, f fun
 
 	err := b.bkt.IterWithAttributes(ctx, dir, f, options...)
 	if err != nil {
-		if !b.metrics.isOpFailureExpected(err) && ctx.Err() != context.Canceled {
+		if b.metrics.isOpFailureExpected(err) {
+			err = nil
+		} else if ctx.Err() != context.Canceled {
 			b.metrics.opsFailures.WithLabelValues(op).Inc()
 		}
 	}

--- a/objstore.go
+++ b/objstore.go
@@ -633,9 +633,12 @@ func (b *metricBucket) Iter(ctx context.Context, dir string, f func(string) erro
 
 	err := b.bkt.Iter(ctx, dir, f, options...)
 	if err != nil {
-		if !b.metrics.isOpFailureExpected(err) && ctx.Err() != context.Canceled {
+		if b.metrics.isOpFailureExpected(err) {
+			err = nil
+		} else if ctx.Err() != context.Canceled {
 			b.metrics.opsFailures.WithLabelValues(op).Inc()
 		}
+		return err
 	}
 	return err
 }
@@ -668,7 +671,9 @@ func (b *metricBucket) Attributes(ctx context.Context, name string) (ObjectAttri
 	start := time.Now()
 	attrs, err := b.bkt.Attributes(ctx, name)
 	if err != nil {
-		if !b.metrics.isOpFailureExpected(err) && ctx.Err() != context.Canceled {
+		if b.metrics.isOpFailureExpected(err) {
+			err = nil
+		} else if ctx.Err() != context.Canceled {
 			b.metrics.opsFailures.WithLabelValues(op).Inc()
 		}
 		return attrs, err
@@ -685,7 +690,9 @@ func (b *metricBucket) Get(ctx context.Context, name string) (io.ReadCloser, err
 
 	rc, err := b.bkt.Get(ctx, name)
 	if err != nil {
-		if !b.metrics.isOpFailureExpected(err) && ctx.Err() != context.Canceled {
+		if b.metrics.isOpFailureExpected(err) {
+			err = nil
+		} else if ctx.Err() != context.Canceled {
 			b.metrics.opsFailures.WithLabelValues(op).Inc()
 		}
 		b.metrics.opsDuration.WithLabelValues(op).Observe(time.Since(start).Seconds())
@@ -712,7 +719,9 @@ func (b *metricBucket) GetRange(ctx context.Context, name string, off, length in
 
 	rc, err := b.bkt.GetRange(ctx, name, off, length)
 	if err != nil {
-		if !b.metrics.isOpFailureExpected(err) && ctx.Err() != context.Canceled {
+		if b.metrics.isOpFailureExpected(err) {
+			err = nil
+		} else if ctx.Err() != context.Canceled {
 			b.metrics.opsFailures.WithLabelValues(op).Inc()
 		}
 		b.metrics.opsDuration.WithLabelValues(op).Observe(time.Since(start).Seconds())
@@ -738,7 +747,9 @@ func (b *metricBucket) Exists(ctx context.Context, name string) (bool, error) {
 	start := time.Now()
 	ok, err := b.bkt.Exists(ctx, name)
 	if err != nil {
-		if !b.metrics.isOpFailureExpected(err) && ctx.Err() != context.Canceled {
+		if b.metrics.isOpFailureExpected(err) {
+			err = nil
+		} else if ctx.Err() != context.Canceled {
 			b.metrics.opsFailures.WithLabelValues(op).Inc()
 		}
 		return false, err
@@ -767,7 +778,9 @@ func (b *metricBucket) Upload(ctx context.Context, name string, r io.Reader) err
 	defer trc.Close()
 	err := b.bkt.Upload(ctx, name, trc)
 	if err != nil {
-		if !b.metrics.isOpFailureExpected(err) && ctx.Err() != context.Canceled {
+		if b.metrics.isOpFailureExpected(err) {
+			err = nil
+		} else if ctx.Err() != context.Canceled {
 			b.metrics.opsFailures.WithLabelValues(op).Inc()
 		}
 		return err
@@ -783,7 +796,9 @@ func (b *metricBucket) Delete(ctx context.Context, name string) error {
 
 	start := time.Now()
 	if err := b.bkt.Delete(ctx, name); err != nil {
-		if !b.metrics.isOpFailureExpected(err) && ctx.Err() != context.Canceled {
+		if b.metrics.isOpFailureExpected(err) {
+			err = nil
+		} else if ctx.Err() != context.Canceled {
 			b.metrics.opsFailures.WithLabelValues(op).Inc()
 		}
 		return err

--- a/objstore_test.go
+++ b/objstore_test.go
@@ -28,7 +28,7 @@ func TestMetricBucket_Close(t *testing.T) {
 	testutil.Equals(t, 7, promtest.CollectAndCount(bkt.metrics.opsFailures))
 	testutil.Equals(t, 7, promtest.CollectAndCount(bkt.metrics.opsDuration))
 
-	AcceptanceTest(t, bkt.WithExpectedErrs(bkt.IsObjNotFoundErr))
+	AcceptanceTest(t, bkt.WithExpectedErrs(bkt.IsObjNotFoundErr), true)
 	testutil.Equals(t, float64(9), promtest.ToFloat64(bkt.metrics.ops.WithLabelValues(OpIter)))
 	testutil.Equals(t, float64(2), promtest.ToFloat64(bkt.metrics.ops.WithLabelValues(OpAttributes)))
 	testutil.Equals(t, float64(3), promtest.ToFloat64(bkt.metrics.ops.WithLabelValues(OpGet)))
@@ -51,7 +51,7 @@ func TestMetricBucket_Close(t *testing.T) {
 
 	// Clear bucket, but don't clear metrics to ensure we use same.
 	bkt.bkt = NewInMemBucket()
-	AcceptanceTest(t, bkt)
+	AcceptanceTestWithoutNotFoundErr(t, bkt)
 	testutil.Equals(t, float64(18), promtest.ToFloat64(bkt.metrics.ops.WithLabelValues(OpIter)))
 	testutil.Equals(t, float64(4), promtest.ToFloat64(bkt.metrics.ops.WithLabelValues(OpAttributes)))
 	testutil.Equals(t, float64(6), promtest.ToFloat64(bkt.metrics.ops.WithLabelValues(OpGet)))

--- a/objtesting/acceptance_e2e_test.go
+++ b/objtesting/acceptance_e2e_test.go
@@ -14,5 +14,5 @@ import (
 // NOTE: This test assumes strong consistency, but in the same way it does not guarantee that if it passes, the
 // used object store is strongly consistent.
 func TestObjStore_AcceptanceTest_e2e(t *testing.T) {
-	ForeachStore(t, objstore.AcceptanceTest)
+	ForeachStore(t, objstore.AcceptanceTestWithoutNotFoundErr)
 }

--- a/prefixed_bucket_test.go
+++ b/prefixed_bucket_test.go
@@ -23,7 +23,7 @@ func TestPrefixedBucket_Acceptance(t *testing.T) {
 		"someprefix"}
 
 	for _, prefix := range prefixes {
-		AcceptanceTest(t, NewPrefixedBucket(NewInMemBucket(), prefix))
+		AcceptanceTestWithoutNotFoundErr(t, NewPrefixedBucket(NewInMemBucket(), prefix))
 		UsesPrefixTest(t, NewInMemBucket(), prefix)
 	}
 }


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "s3:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos Objstore <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/objstore/pull/<PR-id>
    <Component> Component affected by your changes such as s3, azure, cos.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Now, when metric bucket got an error which is `isOpFailureExpected`, it doesn't increment the metric but still returns the error back to the caller.

For example, it is quite common to log the error returned by bucket operations like below. However, even if I already specify `IsXXXError` as expected, the error still returns and will be logged. To filter it out, I need to add another `IsXXXError(err)` check to not log the error, which is very redundant to me.

```
err := userBucket.ReaderWithExpectedErrs(IsXXXError).Iter(...)
level.Log("msg", "got error", "err", err)
```

We also have another usecase which doesn't support checking the error in the caller. https://github.com/cortexproject/cortex/blob/master/pkg/storage/bucket/s3/bucket_client.go#L135

We implemented our own storage provider which has retries. Since the error is returned, there is no way for the retryer to know if the error is expected or not and it will keep retrying and finally log the error. There is no way to inject the expected error to the bucket client itself in this case.

## Verification

<!-- How you tested it? How do you know it works? -->
