### PR TITLE
GCS: Fix logic for allowing Google default logic in gcs provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 ## Unreleased
 
 ### Fixed
+- [#105](https://github.com/thanos-io/objstore/pull/105) GCS: Fix logic for allowing Google default logic in gcs provider
 - [#102](https://github.com/thanos-io/objstore/pull/102) Azure: bump azblob sdk to get concurrency fixes.
 - [#33](https://github.com/thanos-io/objstore/pull/33) Tracing: Add `ContextWithTracer()` to inject the tracer into the context.
 - [#34](https://github.com/thanos-io/objstore/pull/34) Fix ignored options when creating shared credential Azure client.

--- a/providers/gcs/gcs.go
+++ b/providers/gcs/gcs.go
@@ -94,8 +94,6 @@ func NewBucketWithConfig(ctx context.Context, logger log.Logger, gc Config, comp
 			return nil, errors.Wrap(err, "failed to create credentials from JSON")
 		}
 		opts = append(opts, option.WithCredentials(credentials))
-	} else {
-		opts = append(opts, option.WithoutAuthentication())
 	}
 
 	opts = append(opts,


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "s3:" or ".*:"
-->

This PR adds back logic that allows GKE workload identity to work. Fixes #104 

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos Objstore <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/objstore/pull/<PR-id>
    <Component> Component affected by your changes such as s3, azure, cos.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

* Fix logic for allowing Google default logic in gcs provider (GKE workload identity was broken due to setting anonymous auth in GCS provider if not explicitly provider service account credential https://github.com/thanos-io/objstore/pull/86/files#diff-6f1f01a82332f5074843c222ea2e28118de43aa1a516848fe5b7ef3ac18f8470R97-R98)


## Verification

<!-- How you tested it? How do you know it works? -->

I leverage this library in one of my applications to operate on objects in GCS, and when using my branch this works on my local machine when authing to GCS.
