### PR TITLE
GCS: Fix logic for falling back to Google defaults

### DIFF
--- a/providers/gcs/gcs.go
+++ b/providers/gcs/gcs.go
@@ -94,8 +94,6 @@ func NewBucketWithConfig(ctx context.Context, logger log.Logger, gc Config, comp
 			return nil, errors.Wrap(err, "failed to create credentials from JSON")
 		}
 		opts = append(opts, option.WithCredentials(credentials))
-	} else {
-		opts = append(opts, option.WithoutAuthentication())
 	}
 
 	opts = append(opts,

--- a/providers/gcs/gcs_test.go
+++ b/providers/gcs/gcs_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/efficientgo/core/testutil"
 	"github.com/go-kit/log"
 	"github.com/prometheus/common/model"
+	"google.golang.org/api/option"
 )
 
 func TestBucket_Get_ShouldReturnErrorIfServerTruncateResponse(t *testing.T) {
@@ -35,7 +36,8 @@ func TestBucket_Get_ShouldReturnErrorIfServerTruncateResponse(t *testing.T) {
 		ServiceAccount: "",
 	}
 
-	bkt, err := NewBucketWithConfig(context.Background(), log.NewNopLogger(), cfg, "test")
+	// NewBucketWithConfig wraps newBucket and processes HTTP options. Can skip for test.
+	bkt, err := newBucket(context.Background(), log.NewNopLogger(), cfg, []option.ClientOption{})
 	testutil.Ok(t, err)
 
 	reader, err := bkt.Get(context.Background(), "test")


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "s3:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos Objstore <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/objstore/pull/<PR-id>
    <Component> Component affected by your changes such as s3, azure, cos.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Fixes #104 

## Verification

<!-- How you tested it? How do you know it works? -->
