### PR TITLE
azure: Add new storage_create_container configuration property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#108](https://github.com/thanos-io/objstore/pull/108) Metrics: Add native histogram definitions to histograms
 - [#112](https://github.com/thanos-io/objstore/pull/112) S3: Add `DisableDualstack option.
 - [#100](https://github.com/thanos-io/objstore/pull/100) s3: add DisableMultipart option
+- [#116](https://github.com/thanos-io/objstore/pull/116) Azure: Add new storage_create_container configuration property
 
 ### Changed
 - [#38](https://github.com/thanos-io/objstore/pull/38) *: Upgrade minio-go version to `v7.0.45`.


### PR DESCRIPTION
In some cases account does not have permissions to read container properties or create one but has all permissions to do CRUD operations inside the container, e.g SAS tokens. To solve such use case the new configuration property was added for the Azure object storage config which creates a new container explicitly by settings `storage_create_container` to `true` or `false`. To keep backward compatibility with existing object storage configurations the default value for it is always `true`.

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
azure: Add new storage_create_container configuration property

## Verification

<!-- How you tested it? How do you know it works? -->
