### PR TITLE
Update OCI config example to include 'prefix' parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -670,6 +670,7 @@ config:
     max_conns_per_host: 0         // Optional maximum total number of connections per host.
     disable_compression: false    // Optional. If true, prevents the Transport from requesting compression.
     client_timeout: 90s           // Optional time limit for requests made by the HTTP Client.
+prefix: ""
 ```
 
 #### Instance Principal Provider
@@ -682,6 +683,7 @@ config:
   provider: "instance-principal"
   bucket: ""
   compartment_ocid: ""
+prefix: ""
 ```
 
 You can also include any of the optional configuration just like the example in `Default Provider`.
@@ -702,6 +704,7 @@ config:
   fingerprint: ""
   privatekey: ""
   passphrase: ""         // Optional passphrase to encrypt the private API Signing key
+prefix: ""
 ```
 
 You can also include any of the optional configuration just like the example in `Default Provider`.
@@ -716,6 +719,7 @@ config:
   provider: "oke-workload-identity"
   bucket: ""
   region: ""
+prefix: ""
 ```
 
 The `bucket` and `region` fields are required. The `region` field identifies the bucket region.


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "s3:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos Objstore <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/objstore/pull/<PR-id>
    <Component> Component affected by your changes such as s3, azure, cos.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
Updated the readme to show the 'prefix' parameter in the OCI config

## Verification

<!-- How you tested it? How do you know it works? -->
