### PR TITLE
Add support for WriterTo in TimingReader

### DIFF
--- a/objstore.go
+++ b/objstore.go
@@ -728,7 +728,7 @@ func newTimingReader(r io.Reader, closeReader bool, op string, dur *prometheus.H
 
 	_, isSeeker := r.(io.Seeker)
 	_, isReaderAt := r.(io.ReaderAt)
-
+	_, isWriterTo := r.(io.WriterTo)
 	if isSeeker && isReaderAt {
 		// The assumption is that in most cases when io.ReaderAt() is implemented then
 		// io.Seeker is implemented too (e.g. os.File).
@@ -736,6 +736,9 @@ func newTimingReader(r io.Reader, closeReader bool, op string, dur *prometheus.H
 	}
 	if isSeeker {
 		return &timingReaderSeeker{timingReader: trc}
+	}
+	if isWriterTo {
+		return &timingReaderWriterTo{timingReader: trc}
 	}
 
 	return &trc
@@ -801,4 +804,12 @@ type timingReaderSeekerReaderAt struct {
 
 func (rsc *timingReaderSeekerReaderAt) ReadAt(p []byte, off int64) (int, error) {
 	return (rsc.Reader).(io.ReaderAt).ReadAt(p, off)
+}
+
+type timingReaderWriterTo struct {
+	timingReader
+}
+
+func (t *timingReaderWriterTo) WriteTo(w io.Writer) (n int64, err error) {
+	return (t.Reader).(io.WriterTo).WriteTo(w)
 }

--- a/objstore.go
+++ b/objstore.go
@@ -728,7 +728,6 @@ func newTimingReader(r io.Reader, closeReader bool, op string, dur *prometheus.H
 
 	_, isSeeker := r.(io.Seeker)
 	_, isReaderAt := r.(io.ReaderAt)
-	_, isWriterTo := r.(io.WriterTo)
 	if isSeeker && isReaderAt {
 		// The assumption is that in most cases when io.ReaderAt() is implemented then
 		// io.Seeker is implemented too (e.g. os.File).
@@ -737,7 +736,7 @@ func newTimingReader(r io.Reader, closeReader bool, op string, dur *prometheus.H
 	if isSeeker {
 		return &timingReaderSeeker{timingReader: trc}
 	}
-	if isWriterTo {
+	if _, isWriterTo := r.(io.WriterTo); isWriterTo {
 		return &timingReaderWriterTo{timingReader: trc}
 	}
 
@@ -775,11 +774,16 @@ func (r *timingReader) Close() error {
 
 func (r *timingReader) Read(b []byte) (n int, err error) {
 	n, err = r.Reader.Read(b)
+	r.updateMetrics(n, err)
+	return n, err
+}
+
+func (r *timingReader) updateMetrics(n int, err error) {
 	if r.fetchedBytes != nil {
 		r.fetchedBytes.WithLabelValues(r.op).Add(float64(n))
 	}
-
 	r.readBytes += int64(n)
+
 	// Report metric just once.
 	if !r.alreadyGotErr && err != nil && err != io.EOF {
 		if !r.isFailureExpected(err) && !errors.Is(err, context.Canceled) {
@@ -787,7 +791,6 @@ func (r *timingReader) Read(b []byte) (n int, err error) {
 		}
 		r.alreadyGotErr = true
 	}
-	return n, err
 }
 
 type timingReaderSeeker struct {
@@ -811,5 +814,7 @@ type timingReaderWriterTo struct {
 }
 
 func (t *timingReaderWriterTo) WriteTo(w io.Writer) (n int64, err error) {
-	return (t.Reader).(io.WriterTo).WriteTo(w)
+	n, err = (t.Reader).(io.WriterTo).WriteTo(w)
+	t.timingReader.updateMetrics(int(n), err)
+	return n, err
 }


### PR DESCRIPTION
This commit adds support for the WriterTo interface in the TimingReader so that it can be used efficiently in io.Copy.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "s3:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos Objstore <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/objstore/pull/<PR-id>
    <Component> Component affected by your changes such as s3, azure, cos.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
