### PR TITLE
feat(gcs): Add support for `chunkSize` for writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#112](https://github.com/thanos-io/objstore/pull/112) S3: Add `DisableDualstack option.
 - [#100](https://github.com/thanos-io/objstore/pull/100) s3: add DisableMultipart option
 - [#116](https://github.com/thanos-io/objstore/pull/116) Azure: Add new storage_create_container configuration property
+- [#128](https://github.com/thanos-io/objstore/pull/128) GCS: Add support for `ChunkSize` for writer.
 
 ### Changed
 - [#38](https://github.com/thanos-io/objstore/pull/38) *: Upgrade minio-go version to `v7.0.45`.

--- a/providers/gcs/gcs_test.go
+++ b/providers/gcs/gcs_test.go
@@ -87,7 +87,7 @@ func TestParseConfig_ChunkSize(t *testing.T) {
 			},
 		},
 		{
-			name: "DefaultConfig",
+			name: "CustomConfig",
 			input: `bucket: abcd
 chunk_size_bytes: 1024`,
 			assertions: func(cfg Config) {

--- a/providers/gcs/gcs_test.go
+++ b/providers/gcs/gcs_test.go
@@ -73,6 +73,36 @@ func TestNewBucketWithConfig_ShouldCreateGRPC(t *testing.T) {
 	testutil.Assert(t, bkt != nil, "expected bucket to be created")
 }
 
+func TestParseConfig_ChunkSize(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		input      string
+		assertions func(cfg Config)
+	}{
+		{
+			name:  "DefaultConfig",
+			input: `bucket: abcd`,
+			assertions: func(cfg Config) {
+				testutil.Equals(t, cfg.ChunkSizeBytes, 0)
+			},
+		},
+		{
+			name: "DefaultConfig",
+			input: `bucket: abcd
+chunk_size_bytes: 1024`,
+			assertions: func(cfg Config) {
+				testutil.Equals(t, cfg.ChunkSizeBytes, 1024)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := parseConfig([]byte(tc.input))
+			testutil.Ok(t, err)
+			tc.assertions(cfg)
+		})
+	}
+}
+
 func TestParseConfig_HTTPConfig(t *testing.T) {
 	for _, tc := range []struct {
 		name       string


### PR DESCRIPTION

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "s3:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos Objstore <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/objstore/pull/<PR-id>
    <Component> Component affected by your changes such as s3, azure, cos.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This PR add support for custom `ChunkSize` when uploading object via GCS writer. https://pkg.go.dev/google.golang.org/cloud/storage#Writer


## Verification
Add test case to make sure newly added config is parsed correctly.
