### PR TITLE
feat: Decouple creating bucket metrics from instrumenting the bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#100](https://github.com/thanos-io/objstore/pull/100) s3: add DisableMultipart option
 - [#116](https://github.com/thanos-io/objstore/pull/116) Azure: Add new storage_create_container configuration property
 - [#128](https://github.com/thanos-io/objstore/pull/128) GCS: Add support for `ChunkSize` for writer.
+- [#130](https://github.com/thanos-io/objstore/pull/130) feat: Decouple creating bucket metrics from instrumenting the bucket
 
 ### Changed
 - [#38](https://github.com/thanos-io/objstore/pull/38) *: Upgrade minio-go version to `v7.0.45`.

--- a/objstore.go
+++ b/objstore.go
@@ -507,17 +507,6 @@ type Metrics struct {
 	lastSuccessfulUploadTime prometheus.Gauge
 }
 
-func (m *Metrics) mustRegister(reg prometheus.Registerer) {
-	reg.MustRegister(
-		m.ops,
-		m.opsFailures,
-		m.opsFetchedBytes,
-		m.opsTransferredBytes,
-		m.opsDuration,
-		m.lastSuccessfulUploadTime,
-	)
-}
-
 type metricBucket struct {
 	bkt     Bucket
 	metrics *Metrics

--- a/objstore.go
+++ b/objstore.go
@@ -400,11 +400,8 @@ type IsOpFailureExpectedFunc func(error) bool
 
 var _ InstrumentedBucket = &metricBucket{}
 
-// WrapWithMetrics takes a bucket and registers metrics with the given registry for
-// operations run against the bucket.
-func WrapWithMetrics(b Bucket, reg prometheus.Registerer, name string) *metricBucket {
-	bkt := &metricBucket{
-		bkt:                 b,
+func BucketMetrics(reg prometheus.Registerer, name string) *Metrics {
+	return &Metrics{
 		isOpFailureExpected: func(err error) bool { return false },
 		ops: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name:        "objstore_bucket_operations_total",
@@ -430,8 +427,8 @@ func WrapWithMetrics(b Bucket, reg prometheus.Registerer, name string) *metricBu
 			ConstLabels: prometheus.Labels{"bucket": name},
 			Buckets:     prometheus.ExponentialBuckets(2<<14, 2, 16), // 32KiB, 64KiB, ... 1GiB
 			// Use factor=2 for native histograms, which gives similar buckets as the original exponential buckets.
-			NativeHistogramBucketFactor: 2,
-			NativeHistogramMaxBucketNumber: 100,
+			NativeHistogramBucketFactor:     2,
+			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: 1 * time.Hour,
 		}, []string{"operation"}),
 
@@ -441,8 +438,8 @@ func WrapWithMetrics(b Bucket, reg prometheus.Registerer, name string) *metricBu
 			ConstLabels: prometheus.Labels{"bucket": name},
 			Buckets:     []float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120},
 			// Use the recommended defaults for native histograms with 10% growth factor.
-			NativeHistogramBucketFactor: 1.1,
-			NativeHistogramMaxBucketNumber: 100,
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: 1 * time.Hour,
 		}, []string{"operation"}),
 
@@ -452,6 +449,27 @@ func WrapWithMetrics(b Bucket, reg prometheus.Registerer, name string) *metricBu
 			ConstLabels: prometheus.Labels{"bucket": name},
 		}),
 	}
+}
+
+// WrapWithMetrics takes a bucket and registers metrics with the given registry for
+// operations run against the bucket.
+func WrapWithMetrics(b Bucket, reg prometheus.Registerer, name string) *metricBucket {
+	metrics := BucketMetrics(reg, name)
+	return wrapWithMetrics(b, metrics)
+}
+
+// WrapWith takes a `bucket` and `metrics` that returns instrumented bucket.
+// Similar to WrapWithMetrics, but `metrics` can be passed separately as an argument.
+func WrapWith(b Bucket, metrics *Metrics) *metricBucket {
+	return wrapWithMetrics(b, metrics)
+}
+
+func wrapWithMetrics(b Bucket, metrics *Metrics) *metricBucket {
+	bkt := &metricBucket{
+		bkt:     b,
+		metrics: metrics,
+	}
+
 	for _, op := range []string{
 		OpIter,
 		OpGet,
@@ -461,10 +479,10 @@ func WrapWithMetrics(b Bucket, reg prometheus.Registerer, name string) *metricBu
 		OpDelete,
 		OpAttributes,
 	} {
-		bkt.ops.WithLabelValues(op)
-		bkt.opsFailures.WithLabelValues(op)
-		bkt.opsDuration.WithLabelValues(op)
-		bkt.opsFetchedBytes.WithLabelValues(op)
+		bkt.metrics.ops.WithLabelValues(op)
+		bkt.metrics.opsFailures.WithLabelValues(op)
+		bkt.metrics.opsDuration.WithLabelValues(op)
+		bkt.metrics.opsFetchedBytes.WithLabelValues(op)
 	}
 
 	// fetched bytes only relevant for get, getrange and upload
@@ -473,14 +491,12 @@ func WrapWithMetrics(b Bucket, reg prometheus.Registerer, name string) *metricBu
 		OpGetRange,
 		OpUpload,
 	} {
-		bkt.opsTransferredBytes.WithLabelValues(op)
+		bkt.metrics.opsTransferredBytes.WithLabelValues(op)
 	}
 	return bkt
 }
 
-type metricBucket struct {
-	bkt Bucket
-
+type Metrics struct {
 	ops                 *prometheus.CounterVec
 	opsFailures         *prometheus.CounterVec
 	isOpFailureExpected IsOpFailureExpectedFunc
@@ -491,16 +507,34 @@ type metricBucket struct {
 	lastSuccessfulUploadTime prometheus.Gauge
 }
 
+func (m *Metrics) mustRegister(reg prometheus.Registerer) {
+	reg.MustRegister(
+		m.ops,
+		m.opsFailures,
+		m.opsFetchedBytes,
+		m.opsTransferredBytes,
+		m.opsDuration,
+		m.lastSuccessfulUploadTime,
+	)
+}
+
+type metricBucket struct {
+	bkt     Bucket
+	metrics *Metrics
+}
+
 func (b *metricBucket) WithExpectedErrs(fn IsOpFailureExpectedFunc) Bucket {
 	return &metricBucket{
-		bkt:                      b.bkt,
-		ops:                      b.ops,
-		opsFailures:              b.opsFailures,
-		opsFetchedBytes:          b.opsFetchedBytes,
-		opsTransferredBytes:      b.opsTransferredBytes,
-		isOpFailureExpected:      fn,
-		opsDuration:              b.opsDuration,
-		lastSuccessfulUploadTime: b.lastSuccessfulUploadTime,
+		bkt: b.bkt,
+		metrics: &Metrics{
+			ops:                      b.metrics.ops,
+			opsFailures:              b.metrics.opsFailures,
+			opsFetchedBytes:          b.metrics.opsFetchedBytes,
+			opsTransferredBytes:      b.metrics.opsTransferredBytes,
+			isOpFailureExpected:      fn,
+			opsDuration:              b.metrics.opsDuration,
+			lastSuccessfulUploadTime: b.metrics.lastSuccessfulUploadTime,
+		},
 	}
 }
 
@@ -510,43 +544,43 @@ func (b *metricBucket) ReaderWithExpectedErrs(fn IsOpFailureExpectedFunc) Bucket
 
 func (b *metricBucket) Iter(ctx context.Context, dir string, f func(name string) error, options ...IterOption) error {
 	const op = OpIter
-	b.ops.WithLabelValues(op).Inc()
+	b.metrics.ops.WithLabelValues(op).Inc()
 
 	start := time.Now()
 	err := b.bkt.Iter(ctx, dir, f, options...)
 	if err != nil {
-		if !b.isOpFailureExpected(err) && ctx.Err() != context.Canceled {
-			b.opsFailures.WithLabelValues(op).Inc()
+		if !b.metrics.isOpFailureExpected(err) && ctx.Err() != context.Canceled {
+			b.metrics.opsFailures.WithLabelValues(op).Inc()
 		}
 	}
-	b.opsDuration.WithLabelValues(op).Observe(time.Since(start).Seconds())
+	b.metrics.opsDuration.WithLabelValues(op).Observe(time.Since(start).Seconds())
 	return err
 }
 
 func (b *metricBucket) Attributes(ctx context.Context, name string) (ObjectAttributes, error) {
 	const op = OpAttributes
-	b.ops.WithLabelValues(op).Inc()
+	b.metrics.ops.WithLabelValues(op).Inc()
 
 	start := time.Now()
 	attrs, err := b.bkt.Attributes(ctx, name)
 	if err != nil {
-		if !b.isOpFailureExpected(err) && ctx.Err() != context.Canceled {
-			b.opsFailures.WithLabelValues(op).Inc()
+		if !b.metrics.isOpFailureExpected(err) && ctx.Err() != context.Canceled {
+			b.metrics.opsFailures.WithLabelValues(op).Inc()
 		}
 		return attrs, err
 	}
-	b.opsDuration.WithLabelValues(op).Observe(time.Since(start).Seconds())
+	b.metrics.opsDuration.WithLabelValues(op).Observe(time.Since(start).Seconds())
 	return attrs, nil
 }
 
 func (b *metricBucket) Get(ctx context.Context, name string) (io.ReadCloser, error) {
 	const op = OpGet
-	b.ops.WithLabelValues(op).Inc()
+	b.metrics.ops.WithLabelValues(op).Inc()
 
 	rc, err := b.bkt.Get(ctx, name)
 	if err != nil {
-		if !b.isOpFailureExpected(err) && ctx.Err() != context.Canceled {
-			b.opsFailures.WithLabelValues(op).Inc()
+		if !b.metrics.isOpFailureExpected(err) && ctx.Err() != context.Canceled {
+			b.metrics.opsFailures.WithLabelValues(op).Inc()
 		}
 		return nil, err
 	}
@@ -554,22 +588,22 @@ func (b *metricBucket) Get(ctx context.Context, name string) (io.ReadCloser, err
 		rc,
 		true,
 		op,
-		b.opsDuration,
-		b.opsFailures,
-		b.isOpFailureExpected,
-		b.opsFetchedBytes,
-		b.opsTransferredBytes,
+		b.metrics.opsDuration,
+		b.metrics.opsFailures,
+		b.metrics.isOpFailureExpected,
+		b.metrics.opsFetchedBytes,
+		b.metrics.opsTransferredBytes,
 	), nil
 }
 
 func (b *metricBucket) GetRange(ctx context.Context, name string, off, length int64) (io.ReadCloser, error) {
 	const op = OpGetRange
-	b.ops.WithLabelValues(op).Inc()
+	b.metrics.ops.WithLabelValues(op).Inc()
 
 	rc, err := b.bkt.GetRange(ctx, name, off, length)
 	if err != nil {
-		if !b.isOpFailureExpected(err) && ctx.Err() != context.Canceled {
-			b.opsFailures.WithLabelValues(op).Inc()
+		if !b.metrics.isOpFailureExpected(err) && ctx.Err() != context.Canceled {
+			b.metrics.opsFailures.WithLabelValues(op).Inc()
 		}
 		return nil, err
 	}
@@ -577,69 +611,69 @@ func (b *metricBucket) GetRange(ctx context.Context, name string, off, length in
 		rc,
 		true,
 		op,
-		b.opsDuration,
-		b.opsFailures,
-		b.isOpFailureExpected,
-		b.opsFetchedBytes,
-		b.opsTransferredBytes,
+		b.metrics.opsDuration,
+		b.metrics.opsFailures,
+		b.metrics.isOpFailureExpected,
+		b.metrics.opsFetchedBytes,
+		b.metrics.opsTransferredBytes,
 	), nil
 }
 
 func (b *metricBucket) Exists(ctx context.Context, name string) (bool, error) {
 	const op = OpExists
-	b.ops.WithLabelValues(op).Inc()
+	b.metrics.ops.WithLabelValues(op).Inc()
 
 	start := time.Now()
 	ok, err := b.bkt.Exists(ctx, name)
 	if err != nil {
-		if !b.isOpFailureExpected(err) && ctx.Err() != context.Canceled {
-			b.opsFailures.WithLabelValues(op).Inc()
+		if !b.metrics.isOpFailureExpected(err) && ctx.Err() != context.Canceled {
+			b.metrics.opsFailures.WithLabelValues(op).Inc()
 		}
 		return false, err
 	}
-	b.opsDuration.WithLabelValues(op).Observe(time.Since(start).Seconds())
+	b.metrics.opsDuration.WithLabelValues(op).Observe(time.Since(start).Seconds())
 	return ok, nil
 }
 
 func (b *metricBucket) Upload(ctx context.Context, name string, r io.Reader) error {
 	const op = OpUpload
-	b.ops.WithLabelValues(op).Inc()
+	b.metrics.ops.WithLabelValues(op).Inc()
 
 	trc := newTimingReader(
 		r,
 		false,
 		op,
-		b.opsDuration,
-		b.opsFailures,
-		b.isOpFailureExpected,
+		b.metrics.opsDuration,
+		b.metrics.opsFailures,
+		b.metrics.isOpFailureExpected,
 		nil,
-		b.opsTransferredBytes,
+		b.metrics.opsTransferredBytes,
 	)
 	defer trc.Close()
 	err := b.bkt.Upload(ctx, name, trc)
 	if err != nil {
-		if !b.isOpFailureExpected(err) && ctx.Err() != context.Canceled {
-			b.opsFailures.WithLabelValues(op).Inc()
+		if !b.metrics.isOpFailureExpected(err) && ctx.Err() != context.Canceled {
+			b.metrics.opsFailures.WithLabelValues(op).Inc()
 		}
 		return err
 	}
-	b.lastSuccessfulUploadTime.SetToCurrentTime()
+	b.metrics.lastSuccessfulUploadTime.SetToCurrentTime()
 
 	return nil
 }
 
 func (b *metricBucket) Delete(ctx context.Context, name string) error {
 	const op = OpDelete
-	b.ops.WithLabelValues(op).Inc()
+	b.metrics.ops.WithLabelValues(op).Inc()
 
 	start := time.Now()
 	if err := b.bkt.Delete(ctx, name); err != nil {
-		if !b.isOpFailureExpected(err) && ctx.Err() != context.Canceled {
-			b.opsFailures.WithLabelValues(op).Inc()
+		if !b.metrics.isOpFailureExpected(err) && ctx.Err() != context.Canceled {
+			b.metrics.opsFailures.WithLabelValues(op).Inc()
 		}
 		return err
 	}
-	b.opsDuration.WithLabelValues(op).Observe(time.Since(start).Seconds())
+	b.metrics.opsDuration.WithLabelValues(op).Observe(time.Since(start).Seconds())
 
 	return nil
 }

--- a/objstore_test.go
+++ b/objstore_test.go
@@ -23,54 +23,54 @@ import (
 func TestMetricBucket_Close(t *testing.T) {
 	bkt := WrapWithMetrics(NewInMemBucket(), nil, "abc")
 	// Expected initialized metrics.
-	testutil.Equals(t, 7, promtest.CollectAndCount(bkt.ops))
-	testutil.Equals(t, 7, promtest.CollectAndCount(bkt.opsFailures))
-	testutil.Equals(t, 7, promtest.CollectAndCount(bkt.opsDuration))
+	testutil.Equals(t, 7, promtest.CollectAndCount(bkt.metrics.ops))
+	testutil.Equals(t, 7, promtest.CollectAndCount(bkt.metrics.opsFailures))
+	testutil.Equals(t, 7, promtest.CollectAndCount(bkt.metrics.opsDuration))
 
 	AcceptanceTest(t, bkt.WithExpectedErrs(bkt.IsObjNotFoundErr))
-	testutil.Equals(t, float64(9), promtest.ToFloat64(bkt.ops.WithLabelValues(OpIter)))
-	testutil.Equals(t, float64(2), promtest.ToFloat64(bkt.ops.WithLabelValues(OpAttributes)))
-	testutil.Equals(t, float64(3), promtest.ToFloat64(bkt.ops.WithLabelValues(OpGet)))
-	testutil.Equals(t, float64(3), promtest.ToFloat64(bkt.ops.WithLabelValues(OpGetRange)))
-	testutil.Equals(t, float64(2), promtest.ToFloat64(bkt.ops.WithLabelValues(OpExists)))
-	testutil.Equals(t, float64(9), promtest.ToFloat64(bkt.ops.WithLabelValues(OpUpload)))
-	testutil.Equals(t, float64(3), promtest.ToFloat64(bkt.ops.WithLabelValues(OpDelete)))
-	testutil.Equals(t, 7, promtest.CollectAndCount(bkt.ops))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(bkt.opsFailures.WithLabelValues(OpIter)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(bkt.opsFailures.WithLabelValues(OpAttributes)))
-	testutil.Equals(t, float64(1), promtest.ToFloat64(bkt.opsFailures.WithLabelValues(OpGet)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(bkt.opsFailures.WithLabelValues(OpGetRange)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(bkt.opsFailures.WithLabelValues(OpExists)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(bkt.opsFailures.WithLabelValues(OpUpload)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(bkt.opsFailures.WithLabelValues(OpDelete)))
-	testutil.Equals(t, 7, promtest.CollectAndCount(bkt.opsFailures))
-	testutil.Equals(t, 7, promtest.CollectAndCount(bkt.opsDuration))
-	lastUpload := promtest.ToFloat64(bkt.lastSuccessfulUploadTime)
+	testutil.Equals(t, float64(9), promtest.ToFloat64(bkt.metrics.ops.WithLabelValues(OpIter)))
+	testutil.Equals(t, float64(2), promtest.ToFloat64(bkt.metrics.ops.WithLabelValues(OpAttributes)))
+	testutil.Equals(t, float64(3), promtest.ToFloat64(bkt.metrics.ops.WithLabelValues(OpGet)))
+	testutil.Equals(t, float64(3), promtest.ToFloat64(bkt.metrics.ops.WithLabelValues(OpGetRange)))
+	testutil.Equals(t, float64(2), promtest.ToFloat64(bkt.metrics.ops.WithLabelValues(OpExists)))
+	testutil.Equals(t, float64(9), promtest.ToFloat64(bkt.metrics.ops.WithLabelValues(OpUpload)))
+	testutil.Equals(t, float64(3), promtest.ToFloat64(bkt.metrics.ops.WithLabelValues(OpDelete)))
+	testutil.Equals(t, 7, promtest.CollectAndCount(bkt.metrics.ops))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(bkt.metrics.opsFailures.WithLabelValues(OpIter)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(bkt.metrics.opsFailures.WithLabelValues(OpAttributes)))
+	testutil.Equals(t, float64(1), promtest.ToFloat64(bkt.metrics.opsFailures.WithLabelValues(OpGet)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(bkt.metrics.opsFailures.WithLabelValues(OpGetRange)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(bkt.metrics.opsFailures.WithLabelValues(OpExists)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(bkt.metrics.opsFailures.WithLabelValues(OpUpload)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(bkt.metrics.opsFailures.WithLabelValues(OpDelete)))
+	testutil.Equals(t, 7, promtest.CollectAndCount(bkt.metrics.opsFailures))
+	testutil.Equals(t, 7, promtest.CollectAndCount(bkt.metrics.opsDuration))
+	lastUpload := promtest.ToFloat64(bkt.metrics.lastSuccessfulUploadTime)
 	testutil.Assert(t, lastUpload > 0, "last upload not greater than 0, val: %f", lastUpload)
 
 	// Clear bucket, but don't clear metrics to ensure we use same.
 	bkt.bkt = NewInMemBucket()
 	AcceptanceTest(t, bkt)
-	testutil.Equals(t, float64(18), promtest.ToFloat64(bkt.ops.WithLabelValues(OpIter)))
-	testutil.Equals(t, float64(4), promtest.ToFloat64(bkt.ops.WithLabelValues(OpAttributes)))
-	testutil.Equals(t, float64(6), promtest.ToFloat64(bkt.ops.WithLabelValues(OpGet)))
-	testutil.Equals(t, float64(6), promtest.ToFloat64(bkt.ops.WithLabelValues(OpGetRange)))
-	testutil.Equals(t, float64(4), promtest.ToFloat64(bkt.ops.WithLabelValues(OpExists)))
-	testutil.Equals(t, float64(18), promtest.ToFloat64(bkt.ops.WithLabelValues(OpUpload)))
-	testutil.Equals(t, float64(6), promtest.ToFloat64(bkt.ops.WithLabelValues(OpDelete)))
-	testutil.Equals(t, 7, promtest.CollectAndCount(bkt.ops))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(bkt.opsFailures.WithLabelValues(OpIter)))
+	testutil.Equals(t, float64(18), promtest.ToFloat64(bkt.metrics.ops.WithLabelValues(OpIter)))
+	testutil.Equals(t, float64(4), promtest.ToFloat64(bkt.metrics.ops.WithLabelValues(OpAttributes)))
+	testutil.Equals(t, float64(6), promtest.ToFloat64(bkt.metrics.ops.WithLabelValues(OpGet)))
+	testutil.Equals(t, float64(6), promtest.ToFloat64(bkt.metrics.ops.WithLabelValues(OpGetRange)))
+	testutil.Equals(t, float64(4), promtest.ToFloat64(bkt.metrics.ops.WithLabelValues(OpExists)))
+	testutil.Equals(t, float64(18), promtest.ToFloat64(bkt.metrics.ops.WithLabelValues(OpUpload)))
+	testutil.Equals(t, float64(6), promtest.ToFloat64(bkt.metrics.ops.WithLabelValues(OpDelete)))
+	testutil.Equals(t, 7, promtest.CollectAndCount(bkt.metrics.ops))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(bkt.metrics.opsFailures.WithLabelValues(OpIter)))
 	// Not expected not found error here.
-	testutil.Equals(t, float64(1), promtest.ToFloat64(bkt.opsFailures.WithLabelValues(OpAttributes)))
+	testutil.Equals(t, float64(1), promtest.ToFloat64(bkt.metrics.opsFailures.WithLabelValues(OpAttributes)))
 	// Not expected not found errors, this should increment failure metric on get for not found as well, so +2.
-	testutil.Equals(t, float64(3), promtest.ToFloat64(bkt.opsFailures.WithLabelValues(OpGet)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(bkt.opsFailures.WithLabelValues(OpGetRange)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(bkt.opsFailures.WithLabelValues(OpExists)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(bkt.opsFailures.WithLabelValues(OpUpload)))
-	testutil.Equals(t, float64(0), promtest.ToFloat64(bkt.opsFailures.WithLabelValues(OpDelete)))
-	testutil.Equals(t, 7, promtest.CollectAndCount(bkt.opsFailures))
-	testutil.Equals(t, 7, promtest.CollectAndCount(bkt.opsDuration))
-	testutil.Assert(t, promtest.ToFloat64(bkt.lastSuccessfulUploadTime) > lastUpload)
+	testutil.Equals(t, float64(3), promtest.ToFloat64(bkt.metrics.opsFailures.WithLabelValues(OpGet)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(bkt.metrics.opsFailures.WithLabelValues(OpGetRange)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(bkt.metrics.opsFailures.WithLabelValues(OpExists)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(bkt.metrics.opsFailures.WithLabelValues(OpUpload)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(bkt.metrics.opsFailures.WithLabelValues(OpDelete)))
+	testutil.Equals(t, 7, promtest.CollectAndCount(bkt.metrics.opsFailures))
+	testutil.Equals(t, 7, promtest.CollectAndCount(bkt.metrics.opsDuration))
+	testutil.Assert(t, promtest.ToFloat64(bkt.metrics.lastSuccessfulUploadTime) > lastUpload)
 }
 
 // TestMetricBucket_MultipleClients tests that the metrics from two different buckets clients are not conflicting with each other.
@@ -164,8 +164,8 @@ func TestMetricBucket_ReaderClose(t *testing.T) {
 		testutil.Ok(t, reader.Close())
 		testutil.Assert(t, closeCalled)
 
-		testutil.Equals(t, float64(1), promtest.ToFloat64(bucket.ops.WithLabelValues(OpUpload)))
-		testutil.Equals(t, float64(0), promtest.ToFloat64(bucket.opsFailures.WithLabelValues(OpUpload)))
+		testutil.Equals(t, float64(1), promtest.ToFloat64(bucket.metrics.ops.WithLabelValues(OpUpload)))
+		testutil.Equals(t, float64(0), promtest.ToFloat64(bucket.metrics.opsFailures.WithLabelValues(OpUpload)))
 	})
 
 	t.Run("Get() should return a wrapper io.ReadCloser that correctly Close the wrapped one", func(t *testing.T) {
@@ -194,8 +194,8 @@ func TestMetricBucket_ReaderClose(t *testing.T) {
 		testutil.Ok(t, wrappedReader.Close())
 		testutil.Assert(t, closeCalled)
 
-		testutil.Equals(t, float64(1), promtest.ToFloat64(bucket.ops.WithLabelValues(OpGet)))
-		testutil.Equals(t, float64(0), promtest.ToFloat64(bucket.opsFailures.WithLabelValues(OpGet)))
+		testutil.Equals(t, float64(1), promtest.ToFloat64(bucket.metrics.ops.WithLabelValues(OpGet)))
+		testutil.Equals(t, float64(0), promtest.ToFloat64(bucket.metrics.opsFailures.WithLabelValues(OpGet)))
 	})
 
 	t.Run("GetRange() should return a wrapper io.ReadCloser that correctly Close the wrapped one", func(t *testing.T) {
@@ -224,8 +224,8 @@ func TestMetricBucket_ReaderClose(t *testing.T) {
 		testutil.Ok(t, wrappedReader.Close())
 		testutil.Assert(t, closeCalled)
 
-		testutil.Equals(t, float64(1), promtest.ToFloat64(bucket.ops.WithLabelValues(OpGetRange)))
-		testutil.Equals(t, float64(0), promtest.ToFloat64(bucket.opsFailures.WithLabelValues(OpGetRange)))
+		testutil.Equals(t, float64(1), promtest.ToFloat64(bucket.metrics.ops.WithLabelValues(OpGetRange)))
+		testutil.Equals(t, float64(0), promtest.ToFloat64(bucket.metrics.opsFailures.WithLabelValues(OpGetRange)))
 	})
 }
 
@@ -246,8 +246,8 @@ func TestMetricBucket_ReaderCloseError(t *testing.T) {
 
 		testutil.NotOk(t, bucket.Upload(context.Background(), "test", origReader))
 
-		testutil.Equals(t, float64(1), promtest.ToFloat64(bucket.ops.WithLabelValues(OpUpload)))
-		testutil.Equals(t, float64(1), promtest.ToFloat64(bucket.opsFailures.WithLabelValues(OpUpload)))
+		testutil.Equals(t, float64(1), promtest.ToFloat64(bucket.metrics.ops.WithLabelValues(OpUpload)))
+		testutil.Equals(t, float64(1), promtest.ToFloat64(bucket.metrics.opsFailures.WithLabelValues(OpUpload)))
 	})
 
 	t.Run("Get() should track failure if reader Close() returns error", func(t *testing.T) {
@@ -262,8 +262,8 @@ func TestMetricBucket_ReaderCloseError(t *testing.T) {
 		testutil.NotOk(t, reader.Close())
 		testutil.NotOk(t, reader.Close()) // Called twice to ensure metrics are not tracked twice.
 
-		testutil.Equals(t, float64(1), promtest.ToFloat64(bucket.ops.WithLabelValues(OpGet)))
-		testutil.Equals(t, float64(1), promtest.ToFloat64(bucket.opsFailures.WithLabelValues(OpGet)))
+		testutil.Equals(t, float64(1), promtest.ToFloat64(bucket.metrics.ops.WithLabelValues(OpGet)))
+		testutil.Equals(t, float64(1), promtest.ToFloat64(bucket.metrics.opsFailures.WithLabelValues(OpGet)))
 	})
 
 	t.Run("GetRange() should track failure if reader Close() returns error", func(t *testing.T) {
@@ -278,8 +278,8 @@ func TestMetricBucket_ReaderCloseError(t *testing.T) {
 		testutil.NotOk(t, reader.Close())
 		testutil.NotOk(t, reader.Close()) // Called twice to ensure metrics are not tracked twice.
 
-		testutil.Equals(t, float64(1), promtest.ToFloat64(bucket.ops.WithLabelValues(OpGetRange)))
-		testutil.Equals(t, float64(1), promtest.ToFloat64(bucket.opsFailures.WithLabelValues(OpGetRange)))
+		testutil.Equals(t, float64(1), promtest.ToFloat64(bucket.metrics.ops.WithLabelValues(OpGetRange)))
+		testutil.Equals(t, float64(1), promtest.ToFloat64(bucket.metrics.opsFailures.WithLabelValues(OpGetRange)))
 	})
 }
 
@@ -412,9 +412,9 @@ func TestDownloadUploadDirConcurrency(t *testing.T) {
 func TestTimingReader(t *testing.T) {
 	m := WrapWithMetrics(NewInMemBucket(), nil, "")
 	r := bytes.NewReader([]byte("hello world"))
-	tr := newTimingReader(r, true, OpGet, m.opsDuration, m.opsFailures, func(err error) bool {
+	tr := newTimingReader(r, true, OpGet, m.metrics.opsDuration, m.metrics.opsFailures, func(err error) bool {
 		return false
-	}, m.opsFetchedBytes, m.opsTransferredBytes)
+	}, m.metrics.opsFetchedBytes, m.metrics.opsTransferredBytes)
 
 	size, err := TryToGetSize(tr)
 
@@ -439,7 +439,7 @@ func TestTimingReader(t *testing.T) {
 	_, isReaderAt := tr.(io.ReaderAt)
 	testutil.Assert(t, isReaderAt)
 
-	testutil.Equals(t, float64(0), promtest.ToFloat64(m.opsFailures.WithLabelValues(OpGet)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(m.metrics.opsFailures.WithLabelValues(OpGet)))
 }
 
 func TestTimingReader_ExpectedError(t *testing.T) {
@@ -447,13 +447,13 @@ func TestTimingReader_ExpectedError(t *testing.T) {
 
 	m := WrapWithMetrics(NewInMemBucket(), nil, "")
 	r := dummyReader{readerErr}
-	tr := newTimingReader(r, true, OpGet, m.opsDuration, m.opsFailures, func(err error) bool { return errors.Is(err, readerErr) }, m.opsFetchedBytes, m.opsTransferredBytes)
+	tr := newTimingReader(r, true, OpGet, m.metrics.opsDuration, m.metrics.opsFailures, func(err error) bool { return errors.Is(err, readerErr) }, m.metrics.opsFetchedBytes, m.metrics.opsTransferredBytes)
 
 	buf := make([]byte, 1)
 	_, err := io.ReadFull(tr, buf)
 	testutil.Equals(t, readerErr, err)
 
-	testutil.Equals(t, float64(0), promtest.ToFloat64(m.opsFailures.WithLabelValues(OpGet)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(m.metrics.opsFailures.WithLabelValues(OpGet)))
 }
 
 func TestTimingReader_UnexpectedError(t *testing.T) {
@@ -461,13 +461,13 @@ func TestTimingReader_UnexpectedError(t *testing.T) {
 
 	m := WrapWithMetrics(NewInMemBucket(), nil, "")
 	r := dummyReader{readerErr}
-	tr := newTimingReader(r, true, OpGet, m.opsDuration, m.opsFailures, func(err error) bool { return false }, m.opsFetchedBytes, m.opsTransferredBytes)
+	tr := newTimingReader(r, true, OpGet, m.metrics.opsDuration, m.metrics.opsFailures, func(err error) bool { return false }, m.metrics.opsFetchedBytes, m.metrics.opsTransferredBytes)
 
 	buf := make([]byte, 1)
 	_, err := io.ReadFull(tr, buf)
 	testutil.Equals(t, readerErr, err)
 
-	testutil.Equals(t, float64(1), promtest.ToFloat64(m.opsFailures.WithLabelValues(OpGet)))
+	testutil.Equals(t, float64(1), promtest.ToFloat64(m.metrics.opsFailures.WithLabelValues(OpGet)))
 }
 
 func TestTimingReader_ContextCancellation(t *testing.T) {
@@ -476,13 +476,13 @@ func TestTimingReader_ContextCancellation(t *testing.T) {
 
 	m := WrapWithMetrics(NewInMemBucket(), nil, "")
 	r := dummyReader{ctx.Err()}
-	tr := newTimingReader(r, true, OpGet, m.opsDuration, m.opsFailures, func(err error) bool { return false }, m.opsFetchedBytes, m.opsTransferredBytes)
+	tr := newTimingReader(r, true, OpGet, m.metrics.opsDuration, m.metrics.opsFailures, func(err error) bool { return false }, m.metrics.opsFetchedBytes, m.metrics.opsTransferredBytes)
 
 	buf := make([]byte, 1)
 	_, err := io.ReadFull(tr, buf)
 	testutil.Equals(t, ctx.Err(), err)
 
-	testutil.Equals(t, float64(0), promtest.ToFloat64(m.opsFailures.WithLabelValues(OpGet)))
+	testutil.Equals(t, float64(0), promtest.ToFloat64(m.metrics.opsFailures.WithLabelValues(OpGet)))
 }
 
 type dummyReader struct {
@@ -506,9 +506,9 @@ func TestTimingReader_ShouldCorrectlyWrapFile(t *testing.T) {
 	})
 
 	m := WrapWithMetrics(NewInMemBucket(), nil, "")
-	r := newTimingReader(file, true, "", m.opsDuration, m.opsFailures, func(err error) bool {
+	r := newTimingReader(file, true, "", m.metrics.opsDuration, m.metrics.opsFailures, func(err error) bool {
 		return false
-	}, m.opsFetchedBytes, m.opsTransferredBytes)
+	}, m.metrics.opsFetchedBytes, m.metrics.opsTransferredBytes)
 
 	// It must both implement io.Seeker and io.ReaderAt.
 	_, isSeeker := r.(io.Seeker)

--- a/providers/oci/oci.go
+++ b/providers/oci/oci.go
@@ -381,7 +381,6 @@ func NewTestBucket(t testing.TB) (objstore.Bucket, func(), error) {
 	}
 
 	ctx := context.Background()
-	fmt.Println("Debug!!! bkt", bkt)
 	bkt.name = objstore.CreateTemporaryTestBucketName(t)
 	if err := bkt.createBucket(ctx, config.Compartment); err != nil {
 		t.Errorf("failed to create temporary Oracle Cloud Infrastructure bucket '%s' for testing", bkt.name)

--- a/providers/oci/oci.go
+++ b/providers/oci/oci.go
@@ -381,6 +381,7 @@ func NewTestBucket(t testing.TB) (objstore.Bucket, func(), error) {
 	}
 
 	ctx := context.Background()
+	fmt.Println("Debug!!! bkt", bkt)
 	bkt.name = objstore.CreateTemporaryTestBucketName(t)
 	if err := bkt.createBucket(ctx, config.Compartment); err != nil {
 		t.Errorf("failed to create temporary Oracle Cloud Infrastructure bucket '%s' for testing", bkt.name)


### PR DESCRIPTION


<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "s3:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos Objstore <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/objstore/pull/<PR-id>
    <Component> Component affected by your changes such as s3, azure, cos.
-->

* [x] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes
Currently if a single process uses multiple object client, we get metrics duplicate registration failures.

With this PR,
1. New `BucketMetrics` API return just a `Metrics` that can be created once and used for multiple clients.
2. New `Wrap` API that takes `metrics` and returns instrumented bucket just like `WrapWithMetrics` API.

This PR doesn't change any existing API `WrapWithMetrics`

## Verification

Not breaking any existing API(s). All existing tests passes
