### PR TITLE
Pass server-side encryption option to minio.StatObject call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 
 ### Fixed
 - [#153](https://github.com/thanos-io/objstore/pull/153) Metrics: Fix `objstore_bucket_operation_duration_seconds_*` for `get` and `get_range` operations.
+- [#141](https://github.com/thanos-io/objstore/pull/142) S3: Fix missing encryption configuration for `Bucket.Exists()` and `Bucket.Attributes()` calls.
 - [#117](https://github.com/thanos-io/objstore/pull/117) Metrics: Fix `objstore_bucket_operation_failures_total` incorrectly incremented if context is cancelled while reading object contents.
 - [#115](https://github.com/thanos-io/objstore/pull/115) GCS: Fix creation of bucket with GRPC connections. Also update storage client to `v1.40.0`.
 - [#102](https://github.com/thanos-io/objstore/pull/102) Azure: bump azblob sdk to get concurrency fixes.

--- a/providers/s3/s3.go
+++ b/providers/s3/s3.go
@@ -513,7 +513,14 @@ func (b *Bucket) GetRange(ctx context.Context, name string, off, length int64) (
 
 // Exists checks if the given object exists.
 func (b *Bucket) Exists(ctx context.Context, name string) (bool, error) {
-	_, err := b.client.StatObject(ctx, b.name, name, minio.StatObjectOptions{})
+	sse, err := b.getServerSideEncryption(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	_, err = b.client.StatObject(ctx, b.name, name, minio.StatObjectOptions{
+		ServerSideEncryption: sse,
+	})
 	if err != nil {
 		if b.IsObjNotFoundErr(err) {
 			return false, nil
@@ -576,7 +583,14 @@ func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader) error {
 
 // Attributes returns information about the specified object.
 func (b *Bucket) Attributes(ctx context.Context, name string) (objstore.ObjectAttributes, error) {
-	objInfo, err := b.client.StatObject(ctx, b.name, name, minio.StatObjectOptions{})
+	sse, err := b.getServerSideEncryption(ctx)
+	if err != nil {
+		return objstore.ObjectAttributes{}, err
+	}
+
+	objInfo, err := b.client.StatObject(ctx, b.name, name, minio.StatObjectOptions{
+		ServerSideEncryption: sse,
+	})
 	if err != nil {
 		return objstore.ObjectAttributes{}, err
 	}

--- a/providers/s3/s3_e2e_test.go
+++ b/providers/s3/s3_e2e_test.go
@@ -98,7 +98,6 @@ func TestSSECencryption(t *testing.T) {
 	testutil.Ok(t, err)
 
 	upload := "secret content"
-	bkt.Upload(ctx, "encrypted", strings.NewReader(upload))
 	testutil.Ok(t, bkt.Upload(ctx, "encrypted", strings.NewReader(upload)))
 
 	exists, err := bkt.Exists(ctx, "encrypted")

--- a/providers/s3/s3_e2e_test.go
+++ b/providers/s3/s3_e2e_test.go
@@ -94,6 +94,7 @@ func TestSSECencryption(t *testing.T) {
 		log.NewNopLogger(),
 		cfg,
 		"test-ssec",
+		nil,
 	)
 	testutil.Ok(t, err)
 

--- a/providers/s3/s3_e2e_test.go
+++ b/providers/s3/s3_e2e_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/efficientgo/core/testutil"
 	"github.com/efficientgo/e2e"
+	e2edb "github.com/efficientgo/e2e/db"
 	"github.com/go-kit/log"
 	"github.com/minio/minio-go/v7/pkg/encrypt"
 
@@ -71,8 +72,8 @@ func TestSSECencryption(t *testing.T) {
 
 	cfg := s3.Config{
 		Bucket:    bucket,
-		AccessKey: "Cheescake",
-		SecretKey: "supersecret",
+		AccessKey: e2edb.MinioAccessKey,
+		SecretKey: e2edb.MinioSecretKey,
 		Endpoint:  m.Endpoint("https"),
 		Insecure:  false,
 		HTTPConfig: exthttp.HTTPConfig{

--- a/providers/s3/s3_e2e_test.go
+++ b/providers/s3/s3_e2e_test.go
@@ -6,13 +6,17 @@ package s3_test
 import (
 	"bytes"
 	"context"
+	"io"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/efficientgo/core/testutil"
 	"github.com/efficientgo/e2e"
 	"github.com/go-kit/log"
+	"github.com/minio/minio-go/v7/pkg/encrypt"
 
+	"github.com/thanos-io/objstore/exthttp"
 	"github.com/thanos-io/objstore/providers/s3"
 	"github.com/thanos-io/objstore/test/e2e/e2ethanos"
 )
@@ -53,4 +57,58 @@ func BenchmarkUpload(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		testutil.Ok(b, bkt.Upload(ctx, "test", strings.NewReader(str)))
 	}
+}
+
+func TestSSECencryption(t *testing.T) {
+	ctx := context.Background()
+	e, err := e2e.NewDockerEnvironment("e2e-ssec", e2e.WithLogger(log.NewNopLogger()))
+	testutil.Ok(t, err)
+	t.Cleanup(e2ethanos.CleanScenario(t, e))
+
+	const bucket = "sse-c-encryption"
+	m := e2ethanos.NewMinio(e, "sse-c-encryption", bucket)
+	testutil.Ok(t, e2e.StartAndWaitReady(m))
+
+	cfg := s3.Config{
+		Bucket:    bucket,
+		AccessKey: "Cheescake",
+		SecretKey: "supersecret",
+		Endpoint:  m.Endpoint("https"),
+		Insecure:  false,
+		HTTPConfig: exthttp.HTTPConfig{
+			TLSConfig: exthttp.TLSConfig{
+				CAFile:   filepath.Join(m.Dir(), "certs", "CAs", "ca.crt"),
+				CertFile: filepath.Join(m.Dir(), "certs", "public.crt"),
+				KeyFile:  filepath.Join(m.Dir(), "certs", "private.key"),
+			},
+		},
+		SSEConfig: s3.SSEConfig{
+			Type:          string(encrypt.SSEC),
+			EncryptionKey: "testdata/encryption_key",
+		},
+		BucketLookupType: s3.AutoLookup,
+	}
+
+	bkt, err := s3.NewBucketWithConfig(
+		log.NewNopLogger(),
+		cfg,
+		"test-ssec",
+	)
+	testutil.Ok(t, err)
+
+	upload := "secret content"
+	bkt.Upload(ctx, "encrypted", strings.NewReader(upload))
+	testutil.Ok(t, bkt.Upload(ctx, "encrypted", strings.NewReader(upload)))
+
+	exists, err := bkt.Exists(ctx, "encrypted")
+	testutil.Ok(t, err)
+	if !exists {
+		t.Fatalf("upload failed")
+	}
+
+	r, err := bkt.Get(ctx, "encrypted")
+	testutil.Ok(t, err)
+	b, err := io.ReadAll(r)
+	testutil.Ok(t, err)
+	testutil.Equals(t, upload, string(b))
 }

--- a/providers/s3/testdata/encryption_key
+++ b/providers/s3/testdata/encryption_key
@@ -1,0 +1,1 @@
+suchSecretVeryCryptographicKeyZ


### PR DESCRIPTION
Adds missing encryption data passed to `minio.StatObject()` calls, causing client methods `Exists()` and `Attributes()` to fail with a 400 Bad Request error.

This may only affects encryption using `SSE-C` because here it is the callers responsibility to send the encryption key along with the request. In contrast `SSE-KMS` and `SSE-S3` are handled transparently (if the user has permissions to use the key in the casse of `SSE-KMS`)

Fixes #141 
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos Objstore <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/objstore/pull/<PR-id>
    <Component> Component affected by your changes such as s3, azure, cos.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

* Add SSE-C configuration to `Bucket.Exists()`
* Add SSE-C configuration to `Bucket.Attributes()`

## Verification

<!-- How you tested it? How do you know it works? -->
Added E2E-Test that uploads, checks for existence and downloads a file using SSE-C
