### PR TITLE
Added roundtripper wrapper as param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#116](https://github.com/thanos-io/objstore/pull/116) Azure: Add new storage_create_container configuration property
 - [#128](https://github.com/thanos-io/objstore/pull/128) GCS: Add support for `ChunkSize` for writer.
 - [#130](https://github.com/thanos-io/objstore/pull/130) feat: Decouple creating bucket metrics from instrumenting the bucket
-- [#150](https://github.com/thanos-io/objstore/pull/150) Add support of roundtripper wrapper.
+- [#150](https://github.com/thanos-io/objstore/pull/150) Add support for roundtripper wrapper.
 
 ### Changed
 - [#38](https://github.com/thanos-io/objstore/pull/38) *: Upgrade minio-go version to `v7.0.45`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#116](https://github.com/thanos-io/objstore/pull/116) Azure: Add new storage_create_container configuration property
 - [#128](https://github.com/thanos-io/objstore/pull/128) GCS: Add support for `ChunkSize` for writer.
 - [#130](https://github.com/thanos-io/objstore/pull/130) feat: Decouple creating bucket metrics from instrumenting the bucket
+- [#150](https://github.com/thanos-io/objstore/pull/150) Add support of roundtripper wrapper.
 
 ### Changed
 - [#38](https://github.com/thanos-io/objstore/pull/38) *: Upgrade minio-go version to `v7.0.45`.

--- a/client/factory.go
+++ b/client/factory.go
@@ -50,7 +50,7 @@ type BucketConfig struct {
 
 // NewBucket initializes and returns new object storage clients.
 // NOTE: confContentYaml can contain secrets.
-func NewBucket(logger log.Logger, confContentYaml []byte, component string, rt http.RoundTripper) (objstore.Bucket, error) {
+func NewBucket(logger log.Logger, confContentYaml []byte, component string, wrapRoundtripper func(http.RoundTripper) http.RoundTripper) (objstore.Bucket, error) {
 	level.Info(logger).Log("msg", "loading bucket configuration")
 	bucketConf := &BucketConfig{}
 	if err := yaml.UnmarshalStrict(confContentYaml, bucketConf); err != nil {
@@ -65,23 +65,23 @@ func NewBucket(logger log.Logger, confContentYaml []byte, component string, rt h
 	var bucket objstore.Bucket
 	switch strings.ToUpper(string(bucketConf.Type)) {
 	case string(GCS):
-		bucket, err = gcs.NewBucket(context.Background(), logger, config, component, rt)
+		bucket, err = gcs.NewBucket(context.Background(), logger, config, component, wrapRoundtripper)
 	case string(S3):
-		bucket, err = s3.NewBucket(logger, config, component, rt)
+		bucket, err = s3.NewBucket(logger, config, component, wrapRoundtripper)
 	case string(AZURE):
-		bucket, err = azure.NewBucket(logger, config, component, rt)
+		bucket, err = azure.NewBucket(logger, config, component, wrapRoundtripper)
 	case string(SWIFT):
-		bucket, err = swift.NewContainer(logger, config, rt)
+		bucket, err = swift.NewContainer(logger, config, wrapRoundtripper)
 	case string(COS):
-		bucket, err = cos.NewBucket(logger, config, component, rt)
+		bucket, err = cos.NewBucket(logger, config, component, wrapRoundtripper)
 	case string(ALIYUNOSS):
-		bucket, err = oss.NewBucket(logger, config, component, rt)
+		bucket, err = oss.NewBucket(logger, config, component, wrapRoundtripper)
 	case string(FILESYSTEM):
 		bucket, err = filesystem.NewBucketFromConfig(config)
 	case string(BOS):
 		bucket, err = bos.NewBucket(logger, config, component)
 	case string(OCI):
-		bucket, err = oci.NewBucket(logger, config, rt)
+		bucket, err = oci.NewBucket(logger, config, wrapRoundtripper)
 	case string(OBS):
 		bucket, err = obs.NewBucket(logger, config)
 	default:

--- a/errutil/rt_error.go
+++ b/errutil/rt_error.go
@@ -1,8 +1,9 @@
 package errutil
 
 import (
-	"errors"
 	"net/http"
+
+	"github.com/pkg/errors"
 )
 
 var Rt_err = errors.New("RoundTripper error")

--- a/errutil/rt_error.go
+++ b/errutil/rt_error.go
@@ -6,7 +6,11 @@ import (
 	"github.com/pkg/errors"
 )
 
-var Rt_err = errors.New("RoundTripper error")
+var rtErr = errors.New("RoundTripper error")
+
+func IsMockedError(err error) bool {
+	return errors.Is(err, rtErr)
+}
 
 // ErrorRoundTripper is a custom RoundTripper that always returns an error.
 type ErrorRoundTripper struct {
@@ -17,6 +21,6 @@ func (ert *ErrorRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
 	return nil, ert.Err
 }
 
-func WrapRoundtripper(rt http.RoundTripper) http.RoundTripper {
-	return &ErrorRoundTripper{Err: Rt_err}
+func WrapWithErrRoundtripper(rt http.RoundTripper) http.RoundTripper {
+	return &ErrorRoundTripper{Err: rtErr}
 }

--- a/errutil/rt_error.go
+++ b/errutil/rt_error.go
@@ -1,6 +1,11 @@
 package errutil
 
-import "net/http"
+import (
+	"errors"
+	"net/http"
+)
+
+var Rt_err = errors.New("RoundTripper error")
 
 // ErrorRoundTripper is a custom RoundTripper that always returns an error.
 type ErrorRoundTripper struct {
@@ -9,4 +14,8 @@ type ErrorRoundTripper struct {
 
 func (ert *ErrorRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
 	return nil, ert.Err
+}
+
+func WrapRoundtripper(rt http.RoundTripper) http.RoundTripper {
+	return &ErrorRoundTripper{Err: Rt_err}
 }

--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -146,7 +146,7 @@ type Bucket struct {
 }
 
 // NewBucket returns a new Bucket using the provided Azure config.
-func NewBucket(logger log.Logger, azureConfig []byte, component string, rt http.RoundTripper) (*Bucket, error) {
+func NewBucket(logger log.Logger, azureConfig []byte, component string, wrapRoundtripper func(http.RoundTripper) http.RoundTripper) (*Bucket, error) {
 	level.Debug(logger).Log("msg", "creating new Azure bucket connection", "component", component)
 	conf, err := parseConfig(azureConfig)
 	if err != nil {
@@ -155,19 +155,16 @@ func NewBucket(logger log.Logger, azureConfig []byte, component string, rt http.
 	if conf.MSIResource != "" {
 		level.Warn(logger).Log("msg", "The field msi_resource has been deprecated and should no longer be set")
 	}
-	return NewBucketWithConfig(logger, conf, component, rt)
+	return NewBucketWithConfig(logger, conf, component, wrapRoundtripper)
 }
 
 // NewBucketWithConfig returns a new Bucket using the provided Azure config struct.
-func NewBucketWithConfig(logger log.Logger, conf Config, component string, rt http.RoundTripper) (*Bucket, error) {
-	if rt != nil {
-		conf.HTTPConfig.Transport = rt
-	}
+func NewBucketWithConfig(logger log.Logger, conf Config, component string, wrapRoundtripper func(http.RoundTripper) http.RoundTripper) (*Bucket, error) {
 	if err := conf.validate(); err != nil {
 		return nil, err
 	}
 
-	containerClient, err := getContainerClient(conf)
+	containerClient, err := getContainerClient(conf, wrapRoundtripper)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/azure/azure_test.go
+++ b/providers/azure/azure_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/efficientgo/core/testutil"
 	"github.com/go-kit/log"
-	"github.com/pkg/errors"
 
 	"github.com/thanos-io/objstore/errutil"
 	"github.com/thanos-io/objstore/exthttp"
@@ -230,9 +229,9 @@ func TestNewBucketWithErrorRoundTripper(t *testing.T) {
 	cfg, err := parseConfig(validConfig)
 	testutil.Ok(t, err)
 
-	_, err = NewBucketWithConfig(log.NewNopLogger(), cfg, "test", errutil.WrapRoundtripper)
+	_, err = NewBucketWithConfig(log.NewNopLogger(), cfg, "test", errutil.WrapWithErrRoundtripper)
 
 	// We expect an error from the RoundTripper
 	testutil.NotOk(t, err)
-	testutil.Assert(t, errors.Is(err, errutil.Rt_err), "Expected RoundTripper error, got: %v", err)
+	testutil.Assert(t, errutil.IsMockedError(err), "Expected RoundTripper error, got: %v", err)
 }

--- a/providers/azure/azure_test.go
+++ b/providers/azure/azure_test.go
@@ -230,11 +230,9 @@ func TestNewBucketWithErrorRoundTripper(t *testing.T) {
 	cfg, err := parseConfig(validConfig)
 	testutil.Ok(t, err)
 
-	rt := &errutil.ErrorRoundTripper{Err: errors.New("RoundTripper error")}
-
-	_, err = NewBucketWithConfig(log.NewNopLogger(), cfg, "test", rt)
+	_, err = NewBucketWithConfig(log.NewNopLogger(), cfg, "test", errutil.WrapRoundtripper)
 
 	// We expect an error from the RoundTripper
 	testutil.NotOk(t, err)
-	testutil.Assert(t, errors.Is(err, rt.Err), "Expected RoundTripper error, got: %v", err)
+	testutil.Assert(t, errors.Is(err, errutil.Rt_err), "Expected RoundTripper error, got: %v", err)
 }

--- a/providers/azure/helpers.go
+++ b/providers/azure/helpers.go
@@ -19,7 +19,7 @@ import (
 // DirDelim is the delimiter used to model a directory structure in an object store bucket.
 const DirDelim = "/"
 
-func getContainerClient(conf Config) (*container.Client, error) {
+func getContainerClient(conf Config, wrapRoundtripper func(http.RoundTripper) http.RoundTripper) (*container.Client, error) {
 	var rt http.RoundTripper
 	rt, err := exthttp.DefaultTransport(conf.HTTPConfig)
 	if err != nil {
@@ -27,6 +27,9 @@ func getContainerClient(conf Config) (*container.Client, error) {
 	}
 	if conf.HTTPConfig.Transport != nil {
 		rt = conf.HTTPConfig.Transport
+	}
+	if wrapRoundtripper != nil {
+		rt = wrapRoundtripper(rt)
 	}
 	opt := &container.ClientOptions{
 		ClientOptions: azcore.ClientOptions{

--- a/providers/bos/bos.go
+++ b/providers/bos/bos.go
@@ -66,7 +66,7 @@ func parseConfig(conf []byte) (Config, error) {
 
 // NewBucket new bos bucket.
 func NewBucket(logger log.Logger, conf []byte, component string) (*Bucket, error) {
-	// TODO(https://github.com/thanos-io/objstore/pull/140): Add support for custom roundtripper.
+	// TODO(https://github.com/thanos-io/objstore/pull/150): Add support for roundtripper wrapper.
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}

--- a/providers/cos/cos.go
+++ b/providers/cos/cos.go
@@ -95,7 +95,7 @@ func parseConfig(conf []byte) (Config, error) {
 }
 
 // NewBucket returns a new Bucket using the provided cos configuration.
-func NewBucket(logger log.Logger, conf []byte, component string, rt http.RoundTripper) (*Bucket, error) {
+func NewBucket(logger log.Logger, conf []byte, component string, wrapRoundtripper func(http.RoundTripper) http.RoundTripper) (*Bucket, error) {
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
@@ -104,11 +104,11 @@ func NewBucket(logger log.Logger, conf []byte, component string, rt http.RoundTr
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing cos configuration")
 	}
-	return NewBucketWithConfig(logger, config, component, rt)
+	return NewBucketWithConfig(logger, config, component, wrapRoundtripper)
 }
 
 // NewBucketWithConfig returns a new Bucket using the provided cos config values.
-func NewBucketWithConfig(logger log.Logger, config Config, component string, rt http.RoundTripper) (*Bucket, error) {
+func NewBucketWithConfig(logger log.Logger, config Config, component string, wrapRoundtripper func(http.RoundTripper) http.RoundTripper) (*Bucket, error) {
 	if err := config.validate(); err != nil {
 		return nil, errors.Wrap(err, "validate cos configuration")
 	}
@@ -127,19 +127,22 @@ func NewBucketWithConfig(logger log.Logger, config Config, component string, rt 
 		}
 	}
 	b := &cos.BaseURL{BucketURL: bucketURL}
-	var tpt http.RoundTripper
-	tpt, err = exthttp.DefaultTransport(config.HTTPConfig)
+	var rt http.RoundTripper
+	rt, err = exthttp.DefaultTransport(config.HTTPConfig)
 	if err != nil {
 		return nil, err
 	}
-	if rt != nil {
-		tpt = rt
+	if config.HTTPConfig.Transport != nil {
+		rt = config.HTTPConfig.Transport
+	}
+	if wrapRoundtripper != nil {
+		rt = wrapRoundtripper(rt)
 	}
 	client := cos.NewClient(b, &http.Client{
 		Transport: &cos.AuthorizationTransport{
 			SecretID:  config.SecretId,
 			SecretKey: config.SecretKey,
-			Transport: tpt,
+			Transport: rt,
 		},
 	})
 

--- a/providers/cos/cos_test.go
+++ b/providers/cos/cos_test.go
@@ -150,12 +150,11 @@ func TestNewBucketWithErrorRoundTripper(t *testing.T) {
 		SecretId:  "sid",
 		SecretKey: "skey",
 	}
-	rt := &errutil.ErrorRoundTripper{Err: errors.New("RoundTripper error")}
 
-	bkt, err := NewBucketWithConfig(log.NewNopLogger(), config, "test", rt)
+	bkt, err := NewBucketWithConfig(log.NewNopLogger(), config, "test", errutil.WrapRoundtripper)
 	testutil.Ok(t, err)
 	_, err = bkt.Get(context.Background(), "Test")
 	// We expect an error from the RoundTripper
 	testutil.NotOk(t, err)
-	testutil.Assert(t, errors.Is(err, rt.Err), "Expected RoundTripper error, got: %v", err)
+	testutil.Assert(t, errors.Is(err, errutil.Rt_err), "Expected RoundTripper error, got: %v", err)
 }

--- a/providers/cos/cos_test.go
+++ b/providers/cos/cos_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/efficientgo/core/testutil"
 	"github.com/go-kit/log"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 
 	"github.com/thanos-io/objstore/errutil"
@@ -151,10 +150,10 @@ func TestNewBucketWithErrorRoundTripper(t *testing.T) {
 		SecretKey: "skey",
 	}
 
-	bkt, err := NewBucketWithConfig(log.NewNopLogger(), config, "test", errutil.WrapRoundtripper)
+	bkt, err := NewBucketWithConfig(log.NewNopLogger(), config, "test", errutil.WrapWithErrRoundtripper)
 	testutil.Ok(t, err)
 	_, err = bkt.Get(context.Background(), "Test")
 	// We expect an error from the RoundTripper
 	testutil.NotOk(t, err)
-	testutil.Assert(t, errors.Is(err, errutil.Rt_err), "Expected RoundTripper error, got: %v", err)
+	testutil.Assert(t, errutil.IsMockedError(err), "Expected RoundTripper error, got: %v", err)
 }

--- a/providers/gcs/gcs_test.go
+++ b/providers/gcs/gcs_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/efficientgo/core/testutil"
 	"github.com/fullstorydev/emulators/storage/gcsemu"
 	"github.com/go-kit/log"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"github.com/thanos-io/objstore/errutil"
 	"google.golang.org/api/option"
@@ -173,9 +172,9 @@ func TestNewBucketWithErrorRoundTripper(t *testing.T) {
 	err = os.Setenv("STORAGE_EMULATOR_HOST", svr.Addr)
 	testutil.Ok(t, err)
 
-	bkt, err := NewBucketWithConfig(context.Background(), log.NewNopLogger(), cfg, "test-bucket", errutil.WrapRoundtripper)
+	bkt, err := NewBucketWithConfig(context.Background(), log.NewNopLogger(), cfg, "test-bucket", errutil.WrapWithErrRoundtripper)
 	testutil.Ok(t, err)
 	_, err = bkt.Get(context.Background(), "test-bucket")
 	testutil.NotOk(t, err)
-	testutil.Assert(t, errors.Is(err, errutil.Rt_err), "Expected RoundTripper error, got: %v", err)
+	testutil.Assert(t, errutil.IsMockedError(err), "Expected RoundTripper error, got: %v", err)
 }

--- a/providers/gcs/gcs_test.go
+++ b/providers/gcs/gcs_test.go
@@ -161,7 +161,6 @@ http_config:
 }
 
 func TestNewBucketWithErrorRoundTripper(t *testing.T) {
-	rt := &errutil.ErrorRoundTripper{Err: errors.New("RoundTripper error")}
 	cfg := Config{
 		Bucket:         "test-bucket",
 		ServiceAccount: "",
@@ -174,9 +173,9 @@ func TestNewBucketWithErrorRoundTripper(t *testing.T) {
 	err = os.Setenv("STORAGE_EMULATOR_HOST", svr.Addr)
 	testutil.Ok(t, err)
 
-	bkt, err := NewBucketWithConfig(context.Background(), log.NewNopLogger(), cfg, "test-bucket", rt)
+	bkt, err := NewBucketWithConfig(context.Background(), log.NewNopLogger(), cfg, "test-bucket", errutil.WrapRoundtripper)
 	testutil.Ok(t, err)
 	_, err = bkt.Get(context.Background(), "test-bucket")
 	testutil.NotOk(t, err)
-	testutil.Assert(t, errors.Is(err, rt.Err), "Expected RoundTripper error, got: %v", err)
+	testutil.Assert(t, errors.Is(err, errutil.Rt_err), "Expected RoundTripper error, got: %v", err)
 }

--- a/providers/obs/obs.go
+++ b/providers/obs/obs.go
@@ -75,7 +75,7 @@ type Bucket struct {
 }
 
 func NewBucket(logger log.Logger, conf []byte) (*Bucket, error) {
-	// TODO(https://github.com/thanos-io/objstore/pull/140): Add support for custom roundtripper.
+	// TODO(https://github.com/thanos-io/objstore/pull/150): Add support for roundtripper wrapper.
 	config, err := parseConfig(conf)
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing cos configuration")

--- a/providers/oci/oci_test.go
+++ b/providers/oci/oci_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/efficientgo/core/testutil"
 	"github.com/go-kit/log"
-	"github.com/pkg/errors"
 	"github.com/thanos-io/objstore/errutil"
 	"gopkg.in/yaml.v2"
 )
@@ -38,8 +37,8 @@ G6aFKaqQfOXKCyWoUiVknQJAXrlgySFci/2ueKlIE1QqIiLSZ8V8OlpFLRnb1pzI
 	ociConfig, err := yaml.Marshal(config)
 	testutil.Ok(t, err)
 
-	_, err = NewBucket(log.NewNopLogger(), ociConfig, errutil.WrapRoundtripper)
+	_, err = NewBucket(log.NewNopLogger(), ociConfig, errutil.WrapWithErrRoundtripper)
 	// We expect an error from the RoundTripper
 	testutil.NotOk(t, err)
-	testutil.Assert(t, errors.Is(err, errutil.Rt_err), "Expected RoundTripper error, got: %v", err)
+	testutil.Assert(t, errutil.IsMockedError(err), "Expected RoundTripper error, got: %v", err)
 }

--- a/providers/oci/oci_test.go
+++ b/providers/oci/oci_test.go
@@ -38,10 +38,8 @@ G6aFKaqQfOXKCyWoUiVknQJAXrlgySFci/2ueKlIE1QqIiLSZ8V8OlpFLRnb1pzI
 	ociConfig, err := yaml.Marshal(config)
 	testutil.Ok(t, err)
 
-	rt := &errutil.ErrorRoundTripper{Err: errors.New("RoundTripper error")}
-
-	_, err = NewBucket(log.NewNopLogger(), ociConfig, rt)
+	_, err = NewBucket(log.NewNopLogger(), ociConfig, errutil.WrapRoundtripper)
 	// We expect an error from the RoundTripper
 	testutil.NotOk(t, err)
-	testutil.Assert(t, errors.Is(err, rt.Err), "Expected RoundTripper error, got: %v", err)
+	testutil.Assert(t, errors.Is(err, errutil.Rt_err), "Expected RoundTripper error, got: %v", err)
 }

--- a/providers/oss/oss_test.go
+++ b/providers/oss/oss_test.go
@@ -17,12 +17,11 @@ func TestNewBucketWithErrorRoundTripper(t *testing.T) {
 		AccessKeySecret: "123",
 		Bucket:          "test",
 	}
-	rt := &errutil.ErrorRoundTripper{Err: errors.New("RoundTripper error")}
 
-	bkt, err := NewBucketWithConfig(log.NewNopLogger(), config, "test", rt)
+	bkt, err := NewBucketWithConfig(log.NewNopLogger(), config, "test", errutil.WrapRoundtripper)
 	// We expect an error from the RoundTripper
 	testutil.Ok(t, err)
 	_, err = bkt.Get(context.Background(), "test")
 	testutil.NotOk(t, err)
-	testutil.Assert(t, errors.Is(err, rt.Err), "Expected RoundTripper error, got: %v", err)
+	testutil.Assert(t, errors.Is(err, errutil.Rt_err), "Expected RoundTripper error, got: %v", err)
 }

--- a/providers/oss/oss_test.go
+++ b/providers/oss/oss_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/efficientgo/core/testutil"
 	"github.com/go-kit/log"
-	"github.com/pkg/errors"
 	"github.com/thanos-io/objstore/errutil"
 )
 
@@ -18,10 +17,10 @@ func TestNewBucketWithErrorRoundTripper(t *testing.T) {
 		Bucket:          "test",
 	}
 
-	bkt, err := NewBucketWithConfig(log.NewNopLogger(), config, "test", errutil.WrapRoundtripper)
+	bkt, err := NewBucketWithConfig(log.NewNopLogger(), config, "test", errutil.WrapWithErrRoundtripper)
 	// We expect an error from the RoundTripper
 	testutil.Ok(t, err)
 	_, err = bkt.Get(context.Background(), "test")
 	testutil.NotOk(t, err)
-	testutil.Assert(t, errors.Is(err, errutil.Rt_err), "Expected RoundTripper error, got: %v", err)
+	testutil.Assert(t, errutil.IsMockedError(err), "Expected RoundTripper error, got: %v", err)
 }

--- a/providers/s3/s3.go
+++ b/providers/s3/s3.go
@@ -176,13 +176,13 @@ func parseConfig(conf []byte) (Config, error) {
 }
 
 // NewBucket returns a new Bucket using the provided s3 config values.
-func NewBucket(logger log.Logger, conf []byte, component string, rt http.RoundTripper) (*Bucket, error) {
+func NewBucket(logger log.Logger, conf []byte, component string, wrapRoundtripper func(http.RoundTripper) http.RoundTripper) (*Bucket, error) {
 	config, err := parseConfig(conf)
 	if err != nil {
 		return nil, err
 	}
 
-	return NewBucketWithConfig(logger, config, component, rt)
+	return NewBucketWithConfig(logger, config, component, wrapRoundtripper)
 }
 
 type overrideSignerType struct {
@@ -202,7 +202,7 @@ func (s *overrideSignerType) Retrieve() (credentials.Value, error) {
 }
 
 // NewBucketWithConfig returns a new Bucket using the provided s3 config values.
-func NewBucketWithConfig(logger log.Logger, config Config, component string, rt http.RoundTripper) (*Bucket, error) {
+func NewBucketWithConfig(logger log.Logger, config Config, component string, wrapRoundtripper func(http.RoundTripper) http.RoundTripper) (*Bucket, error) {
 	var chain []credentials.Provider
 
 	// TODO(bwplotka): Don't do flags as they won't scale, use actual params like v2, v4 instead
@@ -242,9 +242,7 @@ func NewBucketWithConfig(logger log.Logger, config Config, component string, rt 
 			}),
 		}
 	}
-	if rt != nil {
-		config.HTTPConfig.Transport = rt
-	}
+
 	// Check if a roundtripper has been set in the config
 	// otherwise build the default transport.
 	var tpt http.RoundTripper
@@ -254,6 +252,9 @@ func NewBucketWithConfig(logger log.Logger, config Config, component string, rt 
 	}
 	if config.HTTPConfig.Transport != nil {
 		tpt = config.HTTPConfig.Transport
+	}
+	if wrapRoundtripper != nil {
+		tpt = wrapRoundtripper(tpt)
 	}
 
 	client, err := minio.New(config.Endpoint, &minio.Options{

--- a/providers/s3/s3_test.go
+++ b/providers/s3/s3_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/efficientgo/core/testutil"
 	"github.com/go-kit/log"
 	"github.com/minio/minio-go/v7/pkg/encrypt"
-	"github.com/pkg/errors"
 
 	"github.com/thanos-io/objstore/errutil"
 	"github.com/thanos-io/objstore/exthttp"
@@ -469,10 +468,10 @@ func TestNewBucketWithErrorRoundTripper(t *testing.T) {
 	cfg := DefaultConfig
 	cfg.Endpoint = endpoint
 	cfg.Bucket = "test"
-	bkt, err := NewBucketWithConfig(log.NewNopLogger(), cfg, "test", errutil.WrapRoundtripper)
+	bkt, err := NewBucketWithConfig(log.NewNopLogger(), cfg, "test", errutil.WrapWithErrRoundtripper)
 	testutil.Ok(t, err)
 	_, err = bkt.Get(context.Background(), "test")
 	// We expect an error from the RoundTripper
 	testutil.NotOk(t, err)
-	testutil.Assert(t, errors.Is(err, errutil.Rt_err), "Expected RoundTripper error, got: %v", err)
+	testutil.Assert(t, errutil.IsMockedError(err), "Expected RoundTripper error, got: %v", err)
 }

--- a/providers/s3/s3_test.go
+++ b/providers/s3/s3_test.go
@@ -469,11 +469,10 @@ func TestNewBucketWithErrorRoundTripper(t *testing.T) {
 	cfg := DefaultConfig
 	cfg.Endpoint = endpoint
 	cfg.Bucket = "test"
-	rt := &errutil.ErrorRoundTripper{Err: errors.New("RoundTripper error")}
-	bkt, err := NewBucketWithConfig(log.NewNopLogger(), cfg, "test", rt)
+	bkt, err := NewBucketWithConfig(log.NewNopLogger(), cfg, "test", errutil.WrapRoundtripper)
 	testutil.Ok(t, err)
 	_, err = bkt.Get(context.Background(), "test")
 	// We expect an error from the RoundTripper
 	testutil.NotOk(t, err)
-	testutil.Assert(t, errors.Is(err, rt.Err), "Expected RoundTripper error, got: %v", err)
+	testutil.Assert(t, errors.Is(err, errutil.Rt_err), "Expected RoundTripper error, got: %v", err)
 }

--- a/providers/swift/swift_test.go
+++ b/providers/swift/swift_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/efficientgo/core/testutil"
 	"github.com/go-kit/log"
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"github.com/thanos-io/objstore/errutil"
 )
@@ -71,9 +70,9 @@ http_config:
 func TestNewBucketWithErrorRoundTripper(t *testing.T) {
 	config := DefaultConfig
 	config.AuthUrl = "http://identity.something.com/v3"
-	_, err := NewContainerFromConfig(log.NewNopLogger(), &config, false, errutil.WrapRoundtripper)
+	_, err := NewContainerFromConfig(log.NewNopLogger(), &config, false, errutil.WrapWithErrRoundtripper)
 
 	// We expect an error from the RoundTripper
 	testutil.NotOk(t, err)
-	testutil.Assert(t, errors.Is(err, errutil.Rt_err), "Expected RoundTripper error, got: %v", err)
+	testutil.Assert(t, errutil.IsMockedError(err), "Expected RoundTripper error, got: %v", err)
 }

--- a/providers/swift/swift_test.go
+++ b/providers/swift/swift_test.go
@@ -69,13 +69,11 @@ http_config:
 }
 
 func TestNewBucketWithErrorRoundTripper(t *testing.T) {
-	logger := log.NewNopLogger()
-	rt := &errutil.ErrorRoundTripper{Err: errors.New("RoundTripper error")}
 	config := DefaultConfig
 	config.AuthUrl = "http://identity.something.com/v3"
-	_, err := NewContainerFromConfig(logger, &config, false, rt)
+	_, err := NewContainerFromConfig(log.NewNopLogger(), &config, false, errutil.WrapRoundtripper)
 
 	// We expect an error from the RoundTripper
 	testutil.NotOk(t, err)
-	testutil.Assert(t, errors.Is(err, rt.Err), "Expected RoundTripper error, got: %v", err)
+	testutil.Assert(t, errors.Is(err, errutil.Rt_err), "Expected RoundTripper error, got: %v", err)
 }


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "s3:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos Objstore <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/objstore/pull/<PR-id>
    <Component> Component affected by your changes such as s3, azure, cos.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
Added a parameter in NewBucket() to pass `wrapRoundtripper func(http.RoundTripper) http.RoundTripper`
## Verification

<!-- How you tested it? How do you know it works? -->
Created tests in which a always error returning roundtripper wrapper is passed to NewBucket() and tested whether this error is caught or not.