### PR TITLE
Support io.LimitedReader in object size check

### DIFF
--- a/objstore.go
+++ b/objstore.go
@@ -211,6 +211,8 @@ func TryToGetSize(r io.Reader) (int64, error) {
 		return f.Size(), nil
 	case ObjectSizer:
 		return f.ObjectSize()
+	case *io.LimitedReader:
+		return f.N, nil
 	}
 	return 0, errors.Errorf("unsupported type of io.Reader: %T", r)
 }

--- a/objstore_test.go
+++ b/objstore_test.go
@@ -595,3 +595,11 @@ func (b *mockBucket) GetRange(ctx context.Context, name string, off, length int6
 	}
 	return nil, errors.New("GetRange has not been mocked")
 }
+
+func Test_TryToGetSizeLimitedReader(t *testing.T) {
+	b := &bytes.Buffer{}
+	r := io.LimitReader(b, 1024)
+	size, err := TryToGetSize(r)
+	testutil.Ok(t, err)
+	testutil.Equals(t, int64(1024), size)
+}


### PR DESCRIPTION
Adds support for the `io.LimitedReader` in the `TryToGetSize` function.

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos Objstore <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/objstore/pull/<PR-id>
    <Component> Upload
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Added check in type switch for the io.LimitedReader

## Verification

Added unit test that checks the LimitedReader being supported.
