### PR TITLE
Fix OCI test bucket panic

### DIFF
--- a/providers/oci/oci.go
+++ b/providers/oci/oci.go
@@ -355,7 +355,7 @@ func NewBucket(logger log.Logger, ociConfig []byte, wrapRoundtripper func(http.R
 			return nil, errors.Wrapf(err, "unable to create OKE workload identity config provider")
 		}
 	default:
-		return nil, errors.Wrapf(err, fmt.Sprintf("unsupported OCI provider: %s", provider))
+		return nil, fmt.Errorf("unsupported OCI provider: %s", provider)
 	}
 
 	client, err := objectstorage.NewObjectStorageClientWithConfigurationProvider(configurationProvider)


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "s3:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos Objstore <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/objstore/pull/<PR-id>
    <Component> Component affected by your changes such as s3, azure, cos.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
We are trying to wrap an error which is nil so it ended up return nil.

```
errors.Wrapf(err, fmt.Sprintf("unsupported OCI provider: %s", provider))
```

This caused a panic in Thanos E2E test because `oci.NewTestBucket` tries to reference `bkt` but both bkt and error is nil.

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x105c6b138]

goroutine 1705 [running]:
testing.tRunner.func1.2({0x1068c3ce0, 0x107a4c160})
	/Users/benye/sdk/go1.23.1/src/testing/testing.go:1632 +0x3c0
testing.tRunner.func1()
	/Users/benye/sdk/go1.23.1/src/testing/testing.go:1635 +0x57c
panic({0x1068c3ce0?, 0x107a4c160?})
	/Users/benye/sdk/go1.23.1/src/runtime/panic.go:785 +0xf0
github.com/thanos-io/objstore/providers/oci.NewTestBucket({0x106c2d258, 0x14000035380})
	/Users/benye/go/pkg/mod/github.com/thanos-io/objstore@v0.0.0-20241111205755-d1dd89d41f97/providers/oci/oci.go:417 +0x2c8
github.com/thanos-io/objstore/objtesting.ForeachStore.func10(0x14000035380)
	/Users/benye/go/pkg/mod/github.com/thanos-io/objstore@v0.0.0-20241111205755-d1dd89d41f97/objtesting/foreach.go:178 +0x48
testing.tRunner(0x14000035380, 0x140036e2da0)
	/Users/benye/sdk/go1.23.1/src/testing/testing.go:1690 +0x1a8
created by testing.(*T).Run in goroutine 24
	/Users/benye/sdk/go1.23.1/src/testing/testing.go:1743 +0x668
=== RUN   TestBucketStore_e2e/filesystem
```

## Verification

<!-- How you tested it? How do you know it works? -->
