### PR TITLE
feat(gcs): Support setting endpoint for Google Cloud Storage (GCS) in Thanos

### DIFF
--- a/providers/gcs/gcs.go
+++ b/providers/gcs/gcs.go
@@ -58,7 +58,8 @@ type Config struct {
 	// MaxRetries controls the number of retries for idempotent operations.
 	// Overrides the default gcs storage client behavior if this value is greater than 0.
 	// Set this to 1 to disable retries.
-	MaxRetries int `yaml:"max_retries"`
+	MaxRetries int    `yaml:"max_retries"`
+	Endpoint   string `yaml:"endpoint"`
 }
 
 // Bucket implements the store.Bucket and shipper.Bucket interfaces against GCS.
@@ -119,6 +120,10 @@ func NewBucketWithConfig(ctx context.Context, logger log.Logger, gc Config, comp
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	if gc.Endpoint != "" {
+		opts = append(opts, option.WithEndpoint(gc.Endpoint))
 	}
 
 	return newBucket(ctx, logger, gc, opts)


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "s3:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos Objstore <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/objstore/pull/<PR-id>
    <Component> Component affected by your changes such as s3, azure, cos.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

Part of https://github.com/thanos-io/thanos/issues/7862

- This PR adds an Endpoint field for the `gcs`. Now if the custom endpoint is specified it will overide the default one.