### PR TITLE
Add constructor for a client from a BucketConfig object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#150](https://github.com/thanos-io/objstore/pull/150) Add support for roundtripper wrapper.
 - [#63](https://github.com/thanos-io/objstore/pull/63) Implement a `IterWithAttributes` method on the bucket client.
 - [#155](https://github.com/thanos-io/objstore/pull/155) Add a `Provider` method on `objstore.Client`.
+- [#163](https://github.com/thanos-io/objstore/pull/145) Add a `NewBucketFromConfig` constructor method for creating a client from an existing `BucketConfig` object.
 
 
 ### Changed

--- a/client/factory.go
+++ b/client/factory.go
@@ -42,6 +42,11 @@ func NewBucket(logger log.Logger, confContentYaml []byte, component string, wrap
 		return nil, errors.Wrap(err, "parsing config YAML file")
 	}
 
+	return NewBucketFromConfig(logger, bucketConf, component, wrapRoundtripper)
+}
+
+// NewBucketFromConfig creates an objstore.Bucket from an existing BucketConfig object.
+func NewBucketFromConfig(logger log.Logger, bucketConf *BucketConfig, component string, wrapRoundtripper func(http.RoundTripper) http.RoundTripper) (objstore.Bucket, error) {
 	config, err := yaml.Marshal(bucketConf.Config)
 	if err != nil {
 		return nil, errors.Wrap(err, "marshal content of bucket configuration")


### PR DESCRIPTION
It's handy to be able to create a bucket from an existing BucketConfig object in addition to using raw yaml to do it.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "s3:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos Objstore <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/objstore/pull/<PR-id>
    <Component> Component affected by your changes such as s3, azure, cos.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
