### PR TITLE
Add support for object upload options

### DIFF
--- a/inmem.go
+++ b/inmem.go
@@ -213,7 +213,7 @@ func (b *InMemBucket) Attributes(_ context.Context, name string) (ObjectAttribut
 }
 
 // Upload writes the file specified in src to into the memory.
-func (b *InMemBucket) Upload(_ context.Context, name string, r io.Reader) error {
+func (b *InMemBucket) Upload(_ context.Context, name string, r io.Reader, _ ...ObjectUploadOption) error {
 	b.mtx.Lock()
 	defer b.mtx.Unlock()
 	body, err := io.ReadAll(r)

--- a/objstore_test.go
+++ b/objstore_test.go
@@ -124,7 +124,7 @@ func TestMetricBucket_UploadShouldPreserveReaderFeatures(t *testing.T) {
 
 			m := &mockBucket{
 				Bucket: WrapWithMetrics(NewInMemBucket(), nil, ""),
-				upload: func(ctx context.Context, name string, r io.Reader) error {
+				upload: func(ctx context.Context, name string, r io.Reader, opts ...ObjectUploadOption) error {
 					uploadReader = r
 					return nil
 				},
@@ -570,14 +570,14 @@ func (r *mockReader) Close() error {
 type mockBucket struct {
 	Bucket
 
-	upload   func(ctx context.Context, name string, r io.Reader) error
+	upload   func(ctx context.Context, name string, r io.Reader, opts ...ObjectUploadOption) error
 	get      func(ctx context.Context, name string) (io.ReadCloser, error)
 	getRange func(ctx context.Context, name string, off, length int64) (io.ReadCloser, error)
 }
 
-func (b *mockBucket) Upload(ctx context.Context, name string, r io.Reader) error {
+func (b *mockBucket) Upload(ctx context.Context, name string, r io.Reader, opts ...ObjectUploadOption) error {
 	if b.upload != nil {
-		return b.upload(ctx, name, r)
+		return b.upload(ctx, name, r, opts...)
 	}
 	return errors.New("Upload has not been mocked")
 }

--- a/prefixed_bucket.go
+++ b/prefixed_bucket.go
@@ -101,8 +101,8 @@ func (p *PrefixedBucket) Attributes(ctx context.Context, name string) (ObjectAtt
 
 // Upload the contents of the reader as an object into the bucket.
 // Upload should be idempotent.
-func (p *PrefixedBucket) Upload(ctx context.Context, name string, r io.Reader) error {
-	return p.bkt.Upload(ctx, conditionalPrefix(p.prefix, name), r)
+func (p *PrefixedBucket) Upload(ctx context.Context, name string, r io.Reader, opts ...ObjectUploadOption) error {
+	return p.bkt.Upload(ctx, conditionalPrefix(p.prefix, name), r, opts...)
 }
 
 // Delete removes the object with the given name.

--- a/providers/cos/cos.go
+++ b/providers/cos/cos.go
@@ -213,22 +213,34 @@ func (r fixedLengthReader) Size() int64 {
 }
 
 // Upload the contents of the reader as an object into the bucket.
-func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader) error {
+func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader, opts ...objstore.ObjectUploadOption) error {
 	size, err := objstore.TryToGetSize(r)
 	if err != nil {
 		return errors.Wrapf(err, "getting size of %s", name)
 	}
+	uploadOpts := objstore.ApplyObjectUploadOptions(opts...)
+
 	// partSize 128MB.
 	const partSize = 1024 * 1024 * 128
 	partNums, lastSlice := int(math.Floor(float64(size)/partSize)), size%partSize
 	if partNums == 0 {
-		if _, err := b.client.Object.Put(ctx, name, r, nil); err != nil {
+		cosOpts := &cos.ObjectPutOptions{
+			ObjectPutHeaderOptions: &cos.ObjectPutHeaderOptions{
+				ContentType: uploadOpts.ContentType,
+			},
+		}
+		if _, err := b.client.Object.Put(ctx, name, r, cosOpts); err != nil {
 			return errors.Wrapf(err, "Put object: %s", name)
 		}
 		return nil
 	}
 	// 1. init.
-	result, _, err := b.client.Object.InitiateMultipartUpload(ctx, name, nil)
+	cosOpts := &cos.InitiateMultipartUploadOptions{
+		ObjectPutHeaderOptions: &cos.ObjectPutHeaderOptions{
+			ContentType: uploadOpts.ContentType,
+		},
+	}
+	result, _, err := b.client.Object.InitiateMultipartUpload(ctx, name, cosOpts)
 	if err != nil {
 		return errors.Wrapf(err, "InitiateMultipartUpload %s", name)
 	}

--- a/providers/filesystem/filesystem.go
+++ b/providers/filesystem/filesystem.go
@@ -247,7 +247,7 @@ func (b *Bucket) Exists(ctx context.Context, name string) (bool, error) {
 }
 
 // Upload writes the file specified in src to into the memory.
-func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader) (err error) {
+func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader, _ ...objstore.ObjectUploadOption) (err error) {
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}

--- a/providers/gcs/gcs.go
+++ b/providers/gcs/gcs.go
@@ -332,13 +332,15 @@ func (b *Bucket) Exists(ctx context.Context, name string) (bool, error) {
 }
 
 // Upload writes the file specified in src to remote GCS location specified as target.
-func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader) error {
+func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader, opts ...objstore.ObjectUploadOption) error {
 	w := b.bkt.Object(name).NewWriter(ctx)
 
+	uploadOpts := objstore.ApplyObjectUploadOptions(opts...)
 	// if `chunkSize` is 0, we don't set any custom value for writer's ChunkSize.
 	// It uses whatever the default value https://pkg.go.dev/google.golang.org/cloud/storage#Writer
 	if b.chunkSize > 0 {
 		w.ChunkSize = b.chunkSize
+		w.ContentType = uploadOpts.ContentType
 	}
 
 	if _, err := io.Copy(w, r); err != nil {

--- a/providers/obs/obs.go
+++ b/providers/obs/obs.go
@@ -137,7 +137,7 @@ func (b *Bucket) Delete(ctx context.Context, name string) error {
 }
 
 // Upload the contents of the reader as an object into the bucket.
-func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader) error {
+func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader, opts ...objstore.ObjectUploadOption) error {
 	size, err := objstore.TryToGetSize(r)
 
 	if err != nil {
@@ -147,14 +147,16 @@ func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader) error {
 	if size <= 0 {
 		return errors.New("object size must be provided")
 	}
+
+	uploadOpts := objstore.ApplyObjectUploadOptions(opts...)
 	if size <= MinMultipartUploadSize {
-		err = b.putObjectSingle(name, r)
+		err = b.putObjectSingle(name, r, uploadOpts)
 		if err != nil {
 			return err
 		}
 	} else {
 		var initOutput *obs.InitiateMultipartUploadOutput
-		initOutput, err = b.initiateMultipartUpload(name)
+		initOutput, err = b.initiateMultipartUpload(name, uploadOpts)
 		if err != nil {
 			return err
 		}
@@ -190,11 +192,12 @@ func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader) error {
 	return nil
 }
 
-func (b *Bucket) putObjectSingle(key string, body io.Reader) error {
+func (b *Bucket) putObjectSingle(key string, body io.Reader, opts objstore.UploadObjectParams) error {
 	input := &obs.PutObjectInput{}
 	input.Bucket = b.name
 	input.Key = key
 	input.Body = body
+	input.ContentType = opts.ContentType
 	_, err := b.client.PutObject(input)
 	if err != nil {
 		return errors.Wrap(err, "failed to upload object")
@@ -202,10 +205,11 @@ func (b *Bucket) putObjectSingle(key string, body io.Reader) error {
 	return nil
 }
 
-func (b *Bucket) initiateMultipartUpload(key string) (output *obs.InitiateMultipartUploadOutput, err error) {
+func (b *Bucket) initiateMultipartUpload(key string, opts objstore.UploadObjectParams) (output *obs.InitiateMultipartUploadOutput, err error) {
 	initInput := &obs.InitiateMultipartUploadInput{}
 	initInput.Bucket = b.name
 	initInput.Key = key
+	initInput.ContentType = opts.ContentType
 	initOutput, err := b.client.InitiateMultipartUpload(initInput)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to init multipart upload job")

--- a/providers/oci/oci.go
+++ b/providers/oci/oci.go
@@ -196,7 +196,7 @@ func (b *Bucket) GetRange(ctx context.Context, name string, offset, length int64
 
 // Upload the contents of the reader as an object into the bucket.
 // Upload should be idempotent.
-func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader) (err error) {
+func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader, opts ...objstore.ObjectUploadOption) (err error) {
 	req := transfer.UploadStreamRequest{
 		UploadRequest: transfer.UploadRequest{
 			NamespaceName:                       common.String(b.namespace),
@@ -210,6 +210,11 @@ func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader) (err erro
 	}
 	if b.partSize > 0 {
 		req.UploadRequest.PartSize = &b.partSize
+	}
+
+	uploadOptions := objstore.ApplyObjectUploadOptions(opts...)
+	if uploadOptions.ContentType != "" {
+		req.UploadRequest.ContentType = &uploadOptions.ContentType
 	}
 
 	uploadManager := transfer.NewUploadManager()

--- a/providers/swift/swift.go
+++ b/providers/swift/swift.go
@@ -338,13 +338,16 @@ func (c *Container) IsAccessDeniedErr(err error) bool {
 }
 
 // Upload writes the contents of the reader as an object into the container.
-func (c *Container) Upload(_ context.Context, name string, r io.Reader) (err error) {
+func (c *Container) Upload(_ context.Context, name string, r io.Reader, opts ...objstore.ObjectUploadOption) (err error) {
 	size, err := objstore.TryToGetSize(r)
 	if err != nil {
 		level.Warn(c.logger).Log("msg", "could not guess file size, using large object to avoid issues if the file is larger than limit", "name", name, "err", err)
 		// Anything higher or equal to chunk size so the SLO is used.
 		size = c.chunkSize
 	}
+
+	uploadOpts := objstore.ApplyObjectUploadOptions(opts...)
+
 	var file io.WriteCloser
 	if size >= c.chunkSize {
 		opts := swift.LargeObjectOpts{
@@ -353,6 +356,7 @@ func (c *Container) Upload(_ context.Context, name string, r io.Reader) (err err
 			ChunkSize:        c.chunkSize,
 			SegmentContainer: c.segmentsContainer,
 			CheckHash:        true,
+			ContentType:      uploadOpts.ContentType,
 		}
 		if c.useDynamicLargeObjects {
 			if file, err = c.connection.DynamicLargeObjectCreateFile(&opts); err != nil {
@@ -364,7 +368,7 @@ func (c *Container) Upload(_ context.Context, name string, r io.Reader) (err err
 			}
 		}
 	} else {
-		if file, err = c.connection.ObjectCreate(c.name, name, true, "", "", swift.Headers{}); err != nil {
+		if file, err = c.connection.ObjectCreate(c.name, name, true, "", uploadOpts.ContentType, swift.Headers{}); err != nil {
 			return errors.Wrap(err, "create file")
 		}
 	}

--- a/testing.go
+++ b/testing.go
@@ -316,9 +316,9 @@ func (d *delayingBucket) Exists(ctx context.Context, name string) (bool, error) 
 	return d.bkt.Exists(ctx, name)
 }
 
-func (d *delayingBucket) Upload(ctx context.Context, name string, r io.Reader) error {
+func (d *delayingBucket) Upload(ctx context.Context, name string, r io.Reader, opts ...ObjectUploadOption) error {
 	time.Sleep(d.delay)
-	return d.bkt.Upload(ctx, name, r)
+	return d.bkt.Upload(ctx, name, r, opts...)
 }
 
 func (d *delayingBucket) Delete(ctx context.Context, name string) error {

--- a/tracing/opentelemetry/opentelemetry.go
+++ b/tracing/opentelemetry/opentelemetry.go
@@ -110,7 +110,7 @@ func (t TracingBucket) Attributes(ctx context.Context, name string) (_ objstore.
 	return t.bkt.Attributes(ctx, name)
 }
 
-func (t TracingBucket) Upload(ctx context.Context, name string, r io.Reader) (err error) {
+func (t TracingBucket) Upload(ctx context.Context, name string, r io.Reader, opts ...objstore.ObjectUploadOption) (err error) {
 	ctx, span := t.tracer.Start(ctx, "bucket_upload")
 	defer span.End()
 	span.SetAttributes(attribute.String("name", name))
@@ -120,7 +120,7 @@ func (t TracingBucket) Upload(ctx context.Context, name string, r io.Reader) (er
 			span.RecordError(err)
 		}
 	}()
-	return t.bkt.Upload(ctx, name, r)
+	return t.bkt.Upload(ctx, name, r, opts...)
 }
 
 func (t TracingBucket) Delete(ctx context.Context, name string) (err error) {

--- a/tracing/opentracing/opentracing.go
+++ b/tracing/opentracing/opentracing.go
@@ -110,10 +110,10 @@ func (t TracingBucket) Attributes(ctx context.Context, name string) (attrs objst
 	return
 }
 
-func (t TracingBucket) Upload(ctx context.Context, name string, r io.Reader) (err error) {
+func (t TracingBucket) Upload(ctx context.Context, name string, r io.Reader, opts ...objstore.ObjectUploadOption) (err error) {
 	doWithSpan(ctx, "bucket_upload", func(spanCtx context.Context, span opentracing.Span) {
 		span.LogKV("name", name)
-		err = t.bkt.Upload(spanCtx, name, r)
+		err = t.bkt.Upload(spanCtx, name, r, opts...)
 	})
 	return
 }


### PR DESCRIPTION
I would like to be able to set the content type on uploaded objects since some providers cannot show a preview if the content type is missing.

To facilitate this, I've extended the UploadObject method to accept a variable list of options. The only introduction option is the content type, but it is extensible for other options.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "s3:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos Objstore <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/objstore/pull/<PR-id>
    <Component> Component affected by your changes such as s3, azure, cos.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
