### PR TITLE
Add trimmer for extra field in config yaml

### DIFF
--- a/client/factory.go
+++ b/client/factory.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/thanos-io/objstore"
+	"github.com/thanos-io/objstore/clientutil"
 	"github.com/thanos-io/objstore/providers/azure"
 	"github.com/thanos-io/objstore/providers/bos"
 	"github.com/thanos-io/objstore/providers/cos"
@@ -37,8 +38,12 @@ type BucketConfig struct {
 // NOTE: confContentYaml can contain secrets.
 func NewBucket(logger log.Logger, confContentYaml []byte, component string, wrapRoundtripper func(http.RoundTripper) http.RoundTripper) (objstore.Bucket, error) {
 	level.Info(logger).Log("msg", "loading bucket configuration")
+	trimmedYaml, err := clientutil.TrimExtraFields(confContentYaml)
+	if err != nil {
+		return nil, errors.Wrap(err, "trimming extra fields failed")
+	}
 	bucketConf := &BucketConfig{}
-	if err := yaml.UnmarshalStrict(confContentYaml, bucketConf); err != nil {
+	if err := yaml.UnmarshalStrict(trimmedYaml, bucketConf); err != nil {
 		return nil, errors.Wrap(err, "parsing config YAML file")
 	}
 

--- a/clientutil/trimconfig.go
+++ b/clientutil/trimconfig.go
@@ -1,0 +1,28 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package clientutil
+
+import (
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+)
+
+func TrimExtraFields(confContentYaml []byte) ([]byte, error) {
+	var raw map[string]interface{}
+	if err := yaml.Unmarshal(confContentYaml, &raw); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal YAML")
+	}
+	allowed := map[string]bool{
+		"type":   true,
+		"config": true,
+		"prefix": true,
+	}
+	filtered := make(map[string]interface{})
+	for key, value := range raw {
+		if allowed[key] {
+			filtered[key] = value
+		}
+	}
+	return yaml.Marshal(filtered)
+}

--- a/clientutil/trimconfig_test.go
+++ b/clientutil/trimconfig_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package clientutil
+
+import (
+	"reflect"
+	"testing"
+
+	"gopkg.in/yaml.v2"
+)
+
+func TestTrimExtraFields(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		expected  map[string]interface{}
+		expectErr bool
+	}{
+		{
+			name: "YAML with extra field",
+			input: `
+type: "s3"
+config:
+  key1: "value1"
+  key2: "value2"
+prefix: "/path/to/bucket"
+hedging_config:
+  enabled: false
+  up_to: 3
+  quantile: 0.9
+`,
+			expected: map[string]interface{}{
+				"type":   "s3",
+				"config": map[interface{}]interface{}{"key1": "value1", "key2": "value2"},
+				"prefix": "/path/to/bucket",
+			},
+			expectErr: false,
+		},
+		{
+			name: "YAML without extra field",
+			input: `
+type: "s3"
+config:
+  key: "value"
+prefix: "/path/to/bucket"
+`,
+			expected: map[string]interface{}{
+				"type":   "s3",
+				"config": map[interface{}]interface{}{"key": "value"},
+				"prefix": "/path/to/bucket",
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			output, err := TrimExtraFields([]byte(tc.input))
+			if (err != nil) != tc.expectErr {
+				t.Fatalf("TrimExtraFields() error = %v, expectErr %v", err, tc.expectErr)
+			}
+			if err != nil {
+				return
+			}
+
+			var got map[string]interface{}
+			if err := yaml.Unmarshal(output, &got); err != nil {
+				t.Fatalf("failed to unmarshal output YAML: %v", err)
+			}
+
+			if !reflect.DeepEqual(got, tc.expected) {
+				t.Errorf("TrimExtraFields() got = %v, expected %v", got, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "s3:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos Objstore <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/objstore/pull/<PR-id>
    <Component> Component affected by your changes such as s3, azure, cos.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
New function to trim extra fields from YAML config. 

* [`clientutil/trimconfig.go`](diffhunk://#diff-dd1cabacc4deb1cb3beac6ea61af914d5534a5611a3c56a502c52ffcbe5661baR1-R28): Added a new function `TrimExtraFields` that removes any fields from the YAML configuration that are not explicitly allowed.
<!-- Enumerate changes you made -->

## Verification
* [`clientutil/trimconfig_test.go`](diffhunk://#diff-a221f50cd7508ac36af65ce9b0956a32ef67caa47b9d37311989f9f72807a6bfR1-R77): Added tests for the `TrimExtraFields` function to ensure it correctly filters out unwanted fields from the YAML configuration.

<!-- How you tested it? How do you know it works? -->
