### PR TITLE
GCS: Fix issue where `Exists` returns an error when the object does not exist with GCS client v1.51+

### DIFF
--- a/providers/gcs/gcs.go
+++ b/providers/gcs/gcs.go
@@ -325,7 +325,7 @@ func (b *Bucket) Handle() *storage.BucketHandle {
 func (b *Bucket) Exists(ctx context.Context, name string) (bool, error) {
 	if _, err := b.bkt.Object(name).Attrs(ctx); err == nil {
 		return true, nil
-	} else if err != storage.ErrObjectNotExist {
+	} else if b.IsObjNotFoundErr(err) {
 		return false, err
 	}
 	return false, nil


### PR DESCRIPTION


<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos Objstore <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/objstore/pull/<PR-id>
    <Component> Component affected by your changes such as s3, azure, cos.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

v1.51 of the GCS client includes https://github.com/googleapis/google-cloud-go/pull/11519, which changes the behaviour of `Attrs()` to return a wrapped `ErrObjectNotExist` (rather than `ErrObjectNotExist` itself) when the object does not exist. This breaks the error check done in `Bucket.Exists()` to detect when the object does not exist.

## Verification

<!-- How you tested it? How do you know it works? -->
