### PR TITLE
download: dont cleanup directory after download failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,5 +73,6 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#89](https://github.com/thanos-io/objstore/pull/89) GCS: Upgrade cloud.google.com/go/storage version to `v1.35.1`.
 - [#123](https://github.com/thanos-io/objstore/pull/123) *: Upgrade minio-go version to `v7.0.72`.
 - [#132](https://github.com/thanos-io/objstore/pull/132) s3: Upgrade aws-sdk-go-v2/config version to `v1.27.30`
+- [#182](https://github.com/thanos-io/objstore/pull/182) download: dont cleanup directory after download failed
 
 ### Removed


### PR DESCRIPTION
DownloadDir has the option to ignore paths that we have already on disk. In theory that makes downloads resumable, but in practice this doesnt work because we delete everything if one download fails. This means if one chunk in 1TiB block fails to download for whatever reason we start all over.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "s3:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos Objstore <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/objstore/pull/<PR-id>
    <Component> Component affected by your changes such as s3, azure, cos.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
