### PR TITLE
feat: Add support for non-default google cloud universe domain

### DIFF
--- a/providers/gcs/gcs.go
+++ b/providers/gcs/gcs.go
@@ -59,6 +59,9 @@ type Config struct {
 	// Overrides the default gcs storage client behavior if this value is greater than 0.
 	// Set this to 1 to disable retries.
 	MaxRetries int `yaml:"max_retries"`
+	// UniverseDomain allows overriding the JSON API endpoint,
+	// e.g. "storage.my-company.internal"
+	UniverseDomain string `yaml:"universe_domain"`
 }
 
 // Bucket implements the store.Bucket and shipper.Bucket interfaces against GCS.
@@ -160,6 +163,10 @@ func newBucket(ctx context.Context, logger log.Logger, gc Config, opts []option.
 		err       error
 		gcsClient *storage.Client
 	)
+	// If a custom universe domain is provided, use it for all JSON API calls.
+	if gc.UniverseDomain != "" {
+		opts = append(opts, option.WithUniverseDomain(gc.UniverseDomain))
+	}
 	if gc.UseGRPC {
 		opts = append(opts,
 			option.WithGRPCConnectionPool(gc.GRPCConnPoolSize),

--- a/providers/gcs/gcs_test.go
+++ b/providers/gcs/gcs_test.go
@@ -178,3 +178,12 @@ func TestNewBucketWithErrorRoundTripper(t *testing.T) {
 	testutil.NotOk(t, err)
 	testutil.Assert(t, errutil.IsMockedError(err), "Expected RoundTripper error, got: %v", err)
 }
+
+// TestParseConfig_UniverseDomain ensures that the universe_domain field is correctly parsed.
+func TestParseConfig_UniverseDomain(t *testing.T) {
+	input := `bucket: example-bucket
+universe_domain: storage.custom-domain.internal`
+	cfg, err := parseConfig([]byte(input))
+	testutil.Ok(t, err)
+	testutil.Equals(t, "storage.custom-domain.internal", cfg.UniverseDomain)
+}


### PR DESCRIPTION
## Context & Motivation

Users sometimes need to point GCS clients at self-hosted or alternative JSON API domains. The current GCS provider in `objstore` has no way to override the default Google `universe_domain`.

This PR adds support for a **custom universe domain**, allowing any valid host to be used instead of `storage.googleapis.com`.

## What’s Changed

1. **Configuration** (`providers/gcs/gcs.go`):

   * Added new field to `Config`:

     ```go
     UniverseDomain string `yaml:"universe_domain"`
     ```
   * When `UniverseDomain` is non-empty, append:

     ```go
     option.WithUniverseDomain(gc.UniverseDomain)
     ```

     before creating the GCS client.

2. **Unit Test** (`providers/gcs/gcs_test.go`):

   * New `TestParseConfig_UniverseDomain` to verify YAML parsing of the `universe_domain` field.

## How to Test

* **Unit tests**:

  ```bash
  go test ./providers/gcs -v
  ```

  * All existing tests must pass.
  * The new parsing test must pass.



## Compatibility

* *Backward-compatible*: if `universe_domain` is unset, defaults to Google’s standard endpoint.
* No breaking changes: downstream charts simply gain one new optional value.

## Changelog

* **Added** `Config.UniverseDomain` to GCS provider.
* **Enhanced** `newBucket` to use `option.WithUniverseDomain`.
* **Added** unit test for `universe_domain` parsing.

---

Signed-off-by: Houssein Mnaouar <houssein.mnaouar@gmail.com>