### PR TITLE
OBS: Fix multipart upload error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#157](https://github.com/thanos-io/objstore/pull/157) Azure: Add `az_tenant_id`, `client_id` and `client_secret` configs.
 
 ### Fixed
+- [#227](https://github.com/thanos-io/objstore/pull/227) OBS: Fix multipart upload error.
 - [#196](https://github.com/thanos-io/objstore/pull/196) GCS: fix error check in Exists method when object does not exist.
 - [#153](https://github.com/thanos-io/objstore/pull/153) Metrics: Fix `objstore_bucket_operation_duration_seconds_*` for `get` and `get_range` operations.
 - [#141](https://github.com/thanos-io/objstore/pull/142) S3: Fix missing encryption configuration for `Bucket.Exists()` and `Bucket.Attributes()` calls.

--- a/providers/obs/obs.go
+++ b/providers/obs/obs.go
@@ -223,17 +223,17 @@ func (b *Bucket) multipartUpload(size int64, key, uploadId string, body io.Reade
 	parts := make([]obs.Part, 0, partSum)
 	for i := 1; i <= partSum; i++ {
 		partSize := PartSize
-		if i == partSum {
+		if i == partSum && lastPart > 0 {
 			partSize = lastPart
 		}
+		partReader := io.LimitReader(body, partSize)
 		output, err := b.client.UploadPart(&obs.UploadPartInput{
 			Bucket:     b.name,
 			Key:        key,
 			UploadId:   uploadId,
-			Body:       body,
+			Body:       partReader,
 			PartNumber: i,
 			PartSize:   partSize,
-			Offset:     int64(i-1) * PartSize,
 		})
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to multipart upload")


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

- add checks to prevent zero value for `partSize` when `lastPart` is zero
- fix content-length mismatch due to offset usage, replace the implementation with limitreader like how it's implemented in `cos` and `filesystem`

## Verification
