### PR TITLE
feat(tlsConfig): Add possiblity to trust provided CA and host at the same time

### DIFF
--- a/exthttp/tlsconfig.go
+++ b/exthttp/tlsconfig.go
@@ -14,6 +14,8 @@ import (
 type TLSConfig struct {
 	// The CA cert to use for the targets.
 	CAFile string `yaml:"ca_file"`
+	// Trust RootCAs provided by the host
+	TrustRootCA bool `yaml:"trust_root_ca"`
 	// The client cert file for the targets.
 	CertFile string `yaml:"cert_file"`
 	// The client key file for the targets.
@@ -34,7 +36,7 @@ func NewTLSConfig(cfg *TLSConfig) (*tls.Config, error) {
 		if err != nil {
 			return nil, err
 		}
-		if !updateRootCA(tlsConfig, b) {
+		if !updateRootCA(tlsConfig, b, cfg.TrustRootCA) {
 			return nil, fmt.Errorf("unable to use specified CA cert %s", cfg.CAFile)
 		}
 	}
@@ -68,8 +70,18 @@ func readCAFile(f string) ([]byte, error) {
 }
 
 // updateRootCA parses the given byte slice as a series of PEM encoded certificates and updates tls.Config.RootCAs.
-func updateRootCA(cfg *tls.Config, b []byte) bool {
-	caCertPool := x509.NewCertPool()
+func updateRootCA(cfg *tls.Config, b []byte, trustRootCA bool) bool {
+	var caCertPool *x509.CertPool
+	var err error
+	if trustRootCA {
+		caCertPool, err = x509.SystemCertPool()
+		if err != nil {
+			caCertPool = x509.NewCertPool()
+		}
+	} else {
+		caCertPool = x509.NewCertPool()
+	}
+
 	if !caCertPool.AppendCertsFromPEM(b) {
 		return false
 	}


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This change introduces a new flag in the TLSConfig to leverage both `CACert` provided by end-users and System certificates from the host. 

Until now, it was not possible to do both at the same time, leading to complex configuration when cert chains are too long (k8s size limits for configMaps) or when we share certificates with other application using an "additive system" (as the opposite of the code before this PR). 

## Verification

I tested the code locally, but I'm open to more testing as my client was built into `mimir`, so maybe not good enough. 

**NOTE** I've opened a PR as this change is so small, it would be simpler to discuss around a PR than an issue. If it's ok for you, then I'll modify the changelog and other mandatory items.

Thank you in advance.