### PR TITLE
.*: Add support for StartAfter option in ListObjects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#79](https://github.com/thanos-io/objstore/pull/79) Metrics: Fix `objstore_bucket_operation_duration_seconds` for `iter` operations.
 
 ### Added
+- [#256](https://github.com/thanos-io/objstore/pull/256) Add `WithStartAfter` `IterOption` for listing objects after a given key. Supported by S3, GCS, BOS, COS, OSS, OBS, OCI, and Swift providers.
 - [#15](https://github.com/thanos-io/objstore/pull/15) Add Oracle Cloud Infrastructure Object Storage Bucket support.
 - [#25](https://github.com/thanos-io/objstore/pull/25) S3: Support specifying S3 storage class.
 - [#32](https://github.com/thanos-io/objstore/pull/32) Swift: Support authentication using application credentials.

--- a/inmem.go
+++ b/inmem.go
@@ -125,6 +125,9 @@ func (b *InMemBucket) genericIter(_ context.Context, dir string, f func(string, 
 	})
 
 	for _, k := range keys {
+		if params.StartAfter != "" && k <= params.StartAfter {
+			continue
+		}
 		var modifiedTS time.Time
 		if params.LastModified {
 			modifiedTS = lastModified[k]
@@ -145,7 +148,7 @@ func (b *InMemBucket) Iter(_ context.Context, dir string, f func(string) error, 
 }
 
 func (i *InMemBucket) SupportedIterOptions() []IterOptionType {
-	return []IterOptionType{Recursive, UpdatedAt}
+	return []IterOptionType{Recursive, UpdatedAt, StartAfter}
 }
 
 func (b *InMemBucket) IterWithAttributes(ctx context.Context, dir string, f func(attrs IterObjectAttributes) error, options ...IterOption) error {

--- a/inmem_test.go
+++ b/inmem_test.go
@@ -11,6 +11,67 @@ import (
 	"github.com/efficientgo/core/testutil"
 )
 
+func TestInMem_StartAfter(t *testing.T) {
+	ctx := context.Background()
+	b := NewInMemBucket()
+
+	// Upload objects with known keys.
+	testutil.Ok(t, b.Upload(ctx, "a/file1.txt", strings.NewReader("data1")))
+	testutil.Ok(t, b.Upload(ctx, "b/file2.txt", strings.NewReader("data2")))
+	testutil.Ok(t, b.Upload(ctx, "c/file3.txt", strings.NewReader("data3")))
+	testutil.Ok(t, b.Upload(ctx, "d/file4.txt", strings.NewReader("data4")))
+
+	t.Run("recursive", func(t *testing.T) {
+		var items []string
+		testutil.Ok(t, b.Iter(ctx, "", func(name string) error {
+			items = append(items, name)
+			return nil
+		}, WithRecursiveIter(), WithStartAfter("b/file2.txt")))
+
+		testutil.Equals(t, []string{"c/file3.txt", "d/file4.txt"}, items)
+	})
+
+	t.Run("non-recursive", func(t *testing.T) {
+		var items []string
+		testutil.Ok(t, b.Iter(ctx, "", func(name string) error {
+			items = append(items, name)
+			return nil
+		}, WithStartAfter("b/")))
+
+		testutil.Equals(t, []string{"c/", "d/"}, items)
+	})
+
+	t.Run("start_after_last_key", func(t *testing.T) {
+		var items []string
+		testutil.Ok(t, b.Iter(ctx, "", func(name string) error {
+			items = append(items, name)
+			return nil
+		}, WithRecursiveIter(), WithStartAfter("d/file4.txt")))
+
+		testutil.Equals(t, 0, len(items))
+	})
+
+	t.Run("start_after_empty_string", func(t *testing.T) {
+		var items []string
+		testutil.Ok(t, b.Iter(ctx, "", func(name string) error {
+			items = append(items, name)
+			return nil
+		}, WithRecursiveIter(), WithStartAfter("")))
+
+		testutil.Equals(t, []string{"a/file1.txt", "b/file2.txt", "c/file3.txt", "d/file4.txt"}, items)
+	})
+}
+
+func TestInMem_StartAfter_UnsupportedProvider(t *testing.T) {
+	// Validate that passing StartAfter to a provider that doesn't support it returns an error.
+	err := ValidateIterOptions(
+		[]IterOptionType{Recursive},
+		WithStartAfter("foo"),
+	)
+	testutil.NotOk(t, err)
+	testutil.Assert(t, strings.Contains(err.Error(), "iter option is not supported"), "expected ErrOptionNotSupported")
+}
+
 func TestInMem_ReturnsModifiedInIterAttributes(t *testing.T) {
 	b := NewInMemBucket()
 	testutil.Ok(t, b.Upload(context.Background(), "test/file1.txt", strings.NewReader("test-data1")))

--- a/objstore.go
+++ b/objstore.go
@@ -140,6 +140,7 @@ type IterOptionType int
 const (
 	Recursive IterOptionType = iota
 	UpdatedAt
+	StartAfter
 )
 
 // IterOption configures the provided params.
@@ -176,6 +177,20 @@ func WithUpdatedAt() IterOption {
 type IterParams struct {
 	Recursive    bool
 	LastModified bool
+	StartAfter   string
+}
+
+// WithStartAfter is an option that can be applied to Iter() to only list objects
+// with keys lexicographically after the specified key.
+// Supported by: s3, gcs, bos, cos, oss, obs, oci, swift.
+// Note: GCS (StartOffset) and OCI (Start) use inclusive (>=) semantics; all others are exclusive (>).
+func WithStartAfter(startAfter string) IterOption {
+	return IterOption{
+		Type: StartAfter,
+		Apply: func(params *IterParams) {
+			params.StartAfter = startAfter
+		},
+	}
 }
 
 func ValidateIterOptions(supportedOptions []IterOptionType, options ...IterOption) error {

--- a/objstore_test.go
+++ b/objstore_test.go
@@ -29,7 +29,7 @@ func TestMetricBucket_Close(t *testing.T) {
 	testutil.Equals(t, 7, promtest.CollectAndCount(bkt.metrics.opsDuration))
 
 	AcceptanceTest(t, bkt.WithExpectedErrs(bkt.IsObjNotFoundErr))
-	testutil.Equals(t, float64(9), promtest.ToFloat64(bkt.metrics.ops.WithLabelValues(OpIter)))
+	testutil.Equals(t, float64(11), promtest.ToFloat64(bkt.metrics.ops.WithLabelValues(OpIter)))
 	testutil.Equals(t, float64(2), promtest.ToFloat64(bkt.metrics.ops.WithLabelValues(OpAttributes)))
 	testutil.Equals(t, float64(3), promtest.ToFloat64(bkt.metrics.ops.WithLabelValues(OpGet)))
 	testutil.Equals(t, float64(3), promtest.ToFloat64(bkt.metrics.ops.WithLabelValues(OpGetRange)))
@@ -52,7 +52,7 @@ func TestMetricBucket_Close(t *testing.T) {
 	// Clear bucket, but don't clear metrics to ensure we use same.
 	bkt.bkt = NewInMemBucket()
 	AcceptanceTest(t, bkt)
-	testutil.Equals(t, float64(18), promtest.ToFloat64(bkt.metrics.ops.WithLabelValues(OpIter)))
+	testutil.Equals(t, float64(22), promtest.ToFloat64(bkt.metrics.ops.WithLabelValues(OpIter)))
 	testutil.Equals(t, float64(4), promtest.ToFloat64(bkt.metrics.ops.WithLabelValues(OpAttributes)))
 	testutil.Equals(t, float64(6), promtest.ToFloat64(bkt.metrics.ops.WithLabelValues(OpGet)))
 	testutil.Equals(t, float64(6), promtest.ToFloat64(bkt.metrics.ops.WithLabelValues(OpGetRange)))

--- a/prefixed_bucket.go
+++ b/prefixed_bucket.go
@@ -53,7 +53,7 @@ func (p *PrefixedBucket) Iter(ctx context.Context, dir string, f func(string) er
 
 	return p.bkt.Iter(ctx, pdir, func(s string) error {
 		return f(strings.TrimPrefix(s, p.prefix+DirDelim))
-	}, options...)
+	}, p.prefixIterOptions(options)...)
 }
 
 func (p *PrefixedBucket) IterWithAttributes(ctx context.Context, dir string, f func(IterObjectAttributes) error, options ...IterOption) error {
@@ -62,7 +62,28 @@ func (p *PrefixedBucket) IterWithAttributes(ctx context.Context, dir string, f f
 	return p.bkt.IterWithAttributes(ctx, pdir, func(attrs IterObjectAttributes) error {
 		attrs.Name = strings.TrimPrefix(attrs.Name, p.prefix+DirDelim)
 		return f(attrs)
-	}, options...)
+	}, p.prefixIterOptions(options)...)
+}
+
+// prefixIterOptions adjusts any StartAfter option to include the bucket prefix.
+func (p *PrefixedBucket) prefixIterOptions(options []IterOption) []IterOption {
+	adjusted := make([]IterOption, len(options))
+	copy(adjusted, options)
+	for i, opt := range adjusted {
+		if opt.Type == StartAfter {
+			orig := opt.Apply
+			adjusted[i] = IterOption{
+				Type: StartAfter,
+				Apply: func(params *IterParams) {
+					orig(params)
+					if params.StartAfter != "" {
+						params.StartAfter = withPrefix(p.prefix, params.StartAfter)
+					}
+				},
+			}
+		}
+	}
+	return adjusted
 }
 
 func (p *PrefixedBucket) SupportedIterOptions() []IterOptionType {

--- a/prefixed_bucket.go
+++ b/prefixed_bucket.go
@@ -67,20 +67,17 @@ func (p *PrefixedBucket) IterWithAttributes(ctx context.Context, dir string, f f
 
 // prefixIterOptions adjusts any StartAfter option to include the bucket prefix.
 func (p *PrefixedBucket) prefixIterOptions(options []IterOption) []IterOption {
-	adjusted := make([]IterOption, len(options))
-	copy(adjusted, options)
-	for i, opt := range adjusted {
+	params := ApplyIterOptions(options...)
+	if params.StartAfter == "" {
+		return options
+	}
+
+	adjusted := make([]IterOption, 0, len(options))
+	for _, opt := range options {
 		if opt.Type == StartAfter {
-			orig := opt.Apply
-			adjusted[i] = IterOption{
-				Type: StartAfter,
-				Apply: func(params *IterParams) {
-					orig(params)
-					if params.StartAfter != "" {
-						params.StartAfter = withPrefix(p.prefix, params.StartAfter)
-					}
-				},
-			}
+			adjusted = append(adjusted, WithStartAfter(withPrefix(p.prefix, params.StartAfter)))
+		} else {
+			adjusted = append(adjusted, opt)
 		}
 	}
 	return adjusted

--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -274,12 +274,12 @@ func (b *Bucket) IterWithAttributes(ctx context.Context, dir string, f func(attr
 // Iter calls f for each entry in the given directory. The argument to f is the full
 // object name including the prefix of the inspected directory.
 func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error, opts ...objstore.IterOption) error {
-	// Only include recursive option since attributes are not used in this method.
+	// Only include options that are relevant when attributes are not used.
 	var filteredOpts []objstore.IterOption
 	for _, opt := range opts {
-		if opt.Type == objstore.Recursive {
+		switch opt.Type {
+		case objstore.Recursive, objstore.StartAfter:
 			filteredOpts = append(filteredOpts, opt)
-			break
 		}
 	}
 

--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -274,12 +274,12 @@ func (b *Bucket) IterWithAttributes(ctx context.Context, dir string, f func(attr
 // Iter calls f for each entry in the given directory. The argument to f is the full
 // object name including the prefix of the inspected directory.
 func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error, opts ...objstore.IterOption) error {
-	// Only include options that are relevant when attributes are not used.
+	// Only include recursive option since attributes are not used in this method.
 	var filteredOpts []objstore.IterOption
 	for _, opt := range opts {
-		switch opt.Type {
-		case objstore.Recursive, objstore.StartAfter:
+		if opt.Type == objstore.Recursive {
 			filteredOpts = append(filteredOpts, opt)
+			break
 		}
 	}
 

--- a/providers/bos/bos.go
+++ b/providers/bos/bos.go
@@ -180,7 +180,7 @@ func (b *Bucket) Upload(_ context.Context, name string, r io.Reader, opts ...obj
 }
 
 func (b *Bucket) SupportedIterOptions() []objstore.IterOptionType {
-	return []objstore.IterOptionType{objstore.Recursive, objstore.UpdatedAt}
+	return []objstore.IterOptionType{objstore.Recursive, objstore.UpdatedAt, objstore.StartAfter}
 }
 
 func (b *Bucket) IterWithAttributes(ctx context.Context, dir string, f func(attrs objstore.IterObjectAttributes) error, options ...objstore.IterOption) error {
@@ -199,7 +199,7 @@ func (b *Bucket) IterWithAttributes(ctx context.Context, dir string, f func(attr
 		delimiter = ""
 	}
 
-	var marker string
+	marker := params.StartAfter
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -249,12 +249,12 @@ func (b *Bucket) IterWithAttributes(ctx context.Context, dir string, f func(attr
 // Iter calls f for each entry in the given directory. The argument to f is the full
 // object name including the prefix of the inspected directory.
 func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error, opts ...objstore.IterOption) error {
-	// Only include recursive option since attributes are not used in this method.
+	// Only include supported options since attributes are not used in this method.
 	var filteredOpts []objstore.IterOption
 	for _, opt := range opts {
-		if opt.Type == objstore.Recursive {
+		switch opt.Type {
+		case objstore.Recursive, objstore.StartAfter:
 			filteredOpts = append(filteredOpts, opt)
-			break
 		}
 	}
 

--- a/providers/cos/cos.go
+++ b/providers/cos/cos.go
@@ -296,7 +296,7 @@ func (b *Bucket) Delete(ctx context.Context, name string) error {
 }
 
 func (b *Bucket) SupportedIterOptions() []objstore.IterOptionType {
-	return []objstore.IterOptionType{objstore.Recursive}
+	return []objstore.IterOptionType{objstore.Recursive, objstore.StartAfter}
 }
 
 // Iter calls f for each entry in the given directory. The argument to f is the full
@@ -416,14 +416,15 @@ func (b *Bucket) listObjects(ctx context.Context, objectPrefix string, options .
 	objectsCh := make(chan objectInfo, 1)
 
 	// If recursive iteration is enabled we should pass an empty delimiter.
+	params := objstore.ApplyIterOptions(options...)
 	delimiter := dirDelim
-	if objstore.ApplyIterOptions(options...).Recursive {
+	if params.Recursive {
 		delimiter = ""
 	}
 
 	go func(objectsCh chan<- objectInfo) {
 		defer close(objectsCh)
-		var marker string
+		marker := params.StartAfter
 		for {
 			result, _, err := b.client.Bucket.Get(ctx, &cos.BucketGetOptions{
 				Prefix:    objectPrefix,

--- a/providers/gcs/gcs.go
+++ b/providers/gcs/gcs.go
@@ -194,7 +194,7 @@ func (b *Bucket) Name() string {
 }
 
 func (b *Bucket) SupportedIterOptions() []objstore.IterOptionType {
-	return []objstore.IterOptionType{objstore.Recursive, objstore.UpdatedAt}
+	return []objstore.IterOptionType{objstore.Recursive, objstore.UpdatedAt, objstore.StartAfter}
 }
 
 func (b *Bucket) IterWithAttributes(ctx context.Context, dir string, f func(attrs objstore.IterObjectAttributes) error, options ...objstore.IterOption) error {
@@ -217,8 +217,9 @@ func (b *Bucket) IterWithAttributes(ctx context.Context, dir string, f func(attr
 	}
 
 	query := &storage.Query{
-		Prefix:    dir,
-		Delimiter: delimiter,
+		Prefix:      dir,
+		Delimiter:   delimiter,
+		StartOffset: appliedOpts.StartAfter,
 	}
 	if appliedOpts.LastModified {
 		if err := query.SetAttrSelection([]string{"Name", "Updated"}); err != nil {
@@ -257,12 +258,12 @@ func (b *Bucket) IterWithAttributes(ctx context.Context, dir string, f func(attr
 // Iter calls f for each entry in the given directory. The argument to f is the full
 // object name including the prefix of the inspected directory.
 func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error, opts ...objstore.IterOption) error {
-	// Only include recursive option since attributes are not used in this method.
+	// Only include supported options since attributes are not used in this method.
 	var filteredOpts []objstore.IterOption
 	for _, opt := range opts {
-		if opt.Type == objstore.Recursive {
+		switch opt.Type {
+		case objstore.Recursive, objstore.StartAfter:
 			filteredOpts = append(filteredOpts, opt)
-			break
 		}
 	}
 

--- a/providers/obs/obs.go
+++ b/providers/obs/obs.go
@@ -246,7 +246,7 @@ func (b *Bucket) multipartUpload(size int64, key, uploadId string, body io.Reade
 func (b *Bucket) Close() error { return nil }
 
 func (b *Bucket) SupportedIterOptions() []objstore.IterOptionType {
-	return []objstore.IterOptionType{objstore.Recursive}
+	return []objstore.IterOptionType{objstore.Recursive, objstore.StartAfter}
 }
 
 // Iter calls f for each entry in the given directory (not recursive.)
@@ -255,11 +255,13 @@ func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error, opt
 		dir = strings.TrimSuffix(dir, DirDelim) + DirDelim
 	}
 
+	params := objstore.ApplyIterOptions(options...)
 	input := &obs.ListObjectsInput{}
 	input.Bucket = b.name
 	input.Prefix = dir
 	input.Delimiter = DirDelim
-	if objstore.ApplyIterOptions(options...).Recursive {
+	input.Marker = params.StartAfter
+	if params.Recursive {
 		input.Delimiter = ""
 	}
 	for {

--- a/providers/oci/helper.go
+++ b/providers/oci/helper.go
@@ -70,9 +70,22 @@ func getObject(ctx context.Context, bkt Bucket, objectName string, byteRange str
 }
 
 func listAllObjects(ctx context.Context, bkt Bucket, prefix string, options ...objstore.IterOption) (objectNames []string, err error) {
+	params := objstore.ApplyIterOptions(options...)
+
 	var allObjectNames []string
-	var nextStartWith *string = nil
+	var nextStartWith *string
+	if params.StartAfter != "" {
+		nextStartWith = &params.StartAfter
+	}
 	init := true
+
+	// Filter out StartAfter so recursive subdirectory calls don't reapply it.
+	var subOpts []objstore.IterOption
+	for _, opt := range options {
+		if opt.Type != objstore.StartAfter {
+			subOpts = append(subOpts, opt)
+		}
+	}
 
 	for init || nextStartWith != nil {
 		init = false
@@ -81,10 +94,10 @@ func listAllObjects(ctx context.Context, bkt Bucket, prefix string, options ...o
 			return nil, err
 		}
 
-		if objstore.ApplyIterOptions(options...).Recursive {
+		if params.Recursive {
 			for _, objectName := range objectNames {
 				if strings.HasSuffix(objectName, DirDelim) {
-					subObjectNames, err := listAllObjects(ctx, bkt, objectName, options...)
+					subObjectNames, err := listAllObjects(ctx, bkt, objectName, subOpts...)
 					if err != nil {
 						return nil, err
 					}

--- a/providers/oci/oci.go
+++ b/providers/oci/oci.go
@@ -104,7 +104,7 @@ func (b *Bucket) Name() string {
 }
 
 func (b *Bucket) SupportedIterOptions() []objstore.IterOptionType {
-	return []objstore.IterOptionType{objstore.Recursive}
+	return []objstore.IterOptionType{objstore.Recursive, objstore.StartAfter}
 }
 
 // Iter calls f for each entry in the given directory. The argument to f is the full

--- a/providers/oss/oss.go
+++ b/providers/oss/oss.go
@@ -220,7 +220,7 @@ func validate(config Config) error {
 }
 
 func (b *Bucket) SupportedIterOptions() []objstore.IterOptionType {
-	return []objstore.IterOptionType{objstore.Recursive}
+	return []objstore.IterOptionType{objstore.Recursive, objstore.StartAfter}
 }
 
 // Iter calls f for each entry in the given directory. The argument to f is the full
@@ -230,12 +230,13 @@ func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error, opt
 		dir = strings.TrimSuffix(dir, objstore.DirDelim) + objstore.DirDelim
 	}
 
+	params := objstore.ApplyIterOptions(options...)
 	delimiter := alioss.Delimiter(objstore.DirDelim)
-	if objstore.ApplyIterOptions(options...).Recursive {
+	if params.Recursive {
 		delimiter = nil
 	}
 
-	marker := alioss.Marker("")
+	marker := alioss.Marker(params.StartAfter)
 	for {
 		if err := ctx.Err(); err != nil {
 			return errors.Wrap(err, "context closed while iterating bucket")

--- a/providers/s3/s3.go
+++ b/providers/s3/s3.go
@@ -392,7 +392,7 @@ func ValidateForTests(conf Config) error {
 }
 
 func (b *Bucket) SupportedIterOptions() []objstore.IterOptionType {
-	return []objstore.IterOptionType{objstore.Recursive, objstore.UpdatedAt}
+	return []objstore.IterOptionType{objstore.Recursive, objstore.UpdatedAt, objstore.StartAfter}
 }
 
 func (b *Bucket) IterWithAttributes(ctx context.Context, dir string, f func(attrs objstore.IterObjectAttributes) error, options ...objstore.IterOption) error {
@@ -409,9 +409,10 @@ func (b *Bucket) IterWithAttributes(ctx context.Context, dir string, f func(attr
 	appliedOpts := objstore.ApplyIterOptions(options...)
 
 	opts := minio.ListObjectsOptions{
-		Prefix:    dir,
-		Recursive: appliedOpts.Recursive,
-		UseV1:     b.listObjectsV1,
+		Prefix:     dir,
+		Recursive:  appliedOpts.Recursive,
+		UseV1:      b.listObjectsV1,
+		StartAfter: appliedOpts.StartAfter,
 	}
 
 	for object := range b.client.ListObjects(ctx, b.name, opts) {
@@ -444,12 +445,12 @@ func (b *Bucket) IterWithAttributes(ctx context.Context, dir string, f func(attr
 }
 
 func (b *Bucket) Iter(ctx context.Context, dir string, f func(string) error, opts ...objstore.IterOption) error {
-	// Only include recursive option since attributes are not used in this method.
+	// Only include supported options since attributes are not used in this method.
 	var filteredOpts []objstore.IterOption
 	for _, opt := range opts {
-		if opt.Type == objstore.Recursive {
+		switch opt.Type {
+		case objstore.Recursive, objstore.StartAfter:
 			filteredOpts = append(filteredOpts, opt)
-			break
 		}
 	}
 

--- a/providers/swift/swift.go
+++ b/providers/swift/swift.go
@@ -226,7 +226,7 @@ func (c *Container) Name() string {
 }
 
 func (c *Container) SupportedIterOptions() []objstore.IterOptionType {
-	return []objstore.IterOptionType{objstore.Recursive}
+	return []objstore.IterOptionType{objstore.Recursive, objstore.StartAfter}
 }
 
 // Iter calls f for each entry in the given directory. The argument to f is the full
@@ -236,11 +236,13 @@ func (c *Container) Iter(ctx context.Context, dir string, f func(string) error, 
 		dir = strings.TrimSuffix(dir, string(DirDelim)) + string(DirDelim)
 	}
 
+	params := objstore.ApplyIterOptions(options...)
 	listOptions := &swift.ObjectsOpts{
 		Prefix:    dir,
 		Delimiter: DirDelim,
+		Marker:    params.StartAfter,
 	}
-	if objstore.ApplyIterOptions(options...).Recursive {
+	if params.Recursive {
 		listOptions.Delimiter = rune(0)
 	}
 

--- a/testing.go
+++ b/testing.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -232,6 +233,31 @@ func AcceptanceTest(t *testing.T, bkt Bucket) {
 		return nil
 	}, WithRecursiveIter()))
 	testutil.Equals(t, []string{"id1/obj_1.some", "id1/obj_2.some", "id1/obj_3.some", "id1/sub/subobj_1.some", "id1/sub/subobj_2.some"}, seen)
+
+	// Can we iter with StartAfter?
+	if slices.Contains(bkt.SupportedIterOptions(), StartAfter) {
+		// Non-recursive: start after "id1/" should skip id1/ prefix.
+		seen = []string{}
+		testutil.Ok(t, bkt.Iter(ctx, "", func(fn string) error {
+			seen = append(seen, fn)
+			return nil
+		}, WithStartAfter("id1/")))
+		expected = []string{"id2/", "obj_5.some"}
+		sort.Strings(expected)
+		sort.Strings(seen)
+		testutil.Equals(t, expected, seen)
+
+		// Recursive: start after "id1/obj_2.some" should skip the first two objects.
+		seen = []string{}
+		testutil.Ok(t, bkt.Iter(ctx, "", func(fn string) error {
+			seen = append(seen, fn)
+			return nil
+		}, WithRecursiveIter(), WithStartAfter("id1/obj_2.some")))
+		expected = []string{"id1/obj_3.some", "id1/sub/subobj_1.some", "id1/sub/subobj_2.some", "id2/obj_4.some", "obj_5.some"}
+		sort.Strings(expected)
+		sort.Strings(seen)
+		testutil.Equals(t, expected, seen)
+	}
 
 	// Can we iter over items from not existing dir?
 	testutil.Ok(t, bkt.Iter(ctx, "id0", func(fn string) error {


### PR DESCRIPTION
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos Objstore <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/objstore/pull/<PR-id>
    <Component> Component affected by your changes such as s3, azure, cos.
-->

Thanos compactors have to walk-through and list all metadata files (or block folders depending on the discovery strategy) in S3 before starting compactions. For buckets with dozens of millions of blocks, that sync can take hours, and it has to be started all over every time the compactors are restarted, even if the first sync had finished and compactions had already started.

I’m working on a checkpoint implementation in Thanos to be able to recover a meta sync where it was left after a restart, but for this to work, objstore needs to support StartAfter, StartOffset and Marker as an option for the ListObjects Iter.

I tried to cover as many providers as possible. I checked the documentation for each one to make sure that they take object prefixes as value for the offset.

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

- Added a `WithStartAfter()` option in `objstore.go`.
- Implemented support in 8 providers:
  - S3 (ListObjectsOptions.StartAfter), GCS (Query.StartOffset), BOS/COS/OSS/OBS (Marker), OCI (Start), Swift (ObjectsOpts.Marker).
  - afaict all these options are used to skip objects lexicographically lower than the value, so the implementations are similar.
- Added `StartAfter` handling in `PrefixedBucket` to prepend the bucket prefix to the option value.
- Added `StartAfter` support in `InMemBucket` for testing.
- Not supported (no option in the native API): Azure, Filesystem (maybe?).

## Verification

<!-- How you tested it? How do you know it works? -->

- Added `StartAfter` non-recursive and recursive cases in the `AcceptanceTest`.
- Added `InMemBucket` unit tests covering recursive, non-recursive, and unsupported-provider validation.
- Updated the number of expected iter counts in `TestMetricBucket_Close`.
