### PR TITLE
gcs: add endpoint configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,7 @@ config:
     disable_compression: false
   chunk_size_bytes: 0
   max_retries: 0
+  endpoint: ""
 prefix: ""
 ```
 

--- a/providers/gcs/gcs.go
+++ b/providers/gcs/gcs.go
@@ -59,6 +59,11 @@ type Config struct {
 	// Overrides the default gcs storage client behavior if this value is greater than 0.
 	// Set this to 1 to disable retries.
 	MaxRetries int `yaml:"max_retries"`
+
+	// Endpoint specifies the GCS API endpoint to use.
+	// This can be used to point to GCS regional endpoints or GCS-compatible storage backends.
+	// See https://cloud.google.com/storage/docs/regional-endpoints for more details.
+	Endpoint string `yaml:"endpoint"`
 }
 
 // Bucket implements the store.Bucket and shipper.Bucket interfaces against GCS.
@@ -112,6 +117,10 @@ func NewBucketWithConfig(ctx context.Context, logger log.Logger, gc Config, comp
 	opts = append(opts,
 		option.WithUserAgent(fmt.Sprintf("thanos-%s/%s (%s)", component, version.Version, runtime.Version())),
 	)
+
+	if gc.Endpoint != "" {
+		opts = append(opts, option.WithEndpoint(gc.Endpoint))
+	}
 
 	if !gc.UseGRPC {
 		var err error

--- a/providers/gcs/gcs_test.go
+++ b/providers/gcs/gcs_test.go
@@ -159,6 +159,55 @@ http_config:
 	}
 }
 
+func TestParseConfig_Endpoint(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		input      string
+		assertions func(cfg Config)
+	}{
+		{
+			name:  "DefaultEndpoint",
+			input: `bucket: abcd`,
+			assertions: func(cfg Config) {
+				testutil.Equals(t, "", cfg.Endpoint)
+			},
+		},
+		{
+			name: "CustomEndpoint",
+			input: `bucket: abcd
+endpoint: https://storage.europe-west3.rep.googleapis.com`,
+			assertions: func(cfg Config) {
+				testutil.Equals(t, "https://storage.europe-west3.rep.googleapis.com", cfg.Endpoint)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := parseConfig([]byte(tc.input))
+			testutil.Ok(t, err)
+			tc.assertions(cfg)
+		})
+	}
+}
+
+func TestNewBucketWithConfig_CustomEndpoint(t *testing.T) {
+	svr, err := gcsemu.NewServer("127.0.0.1:0", gcsemu.Options{})
+	testutil.Ok(t, err)
+	defer svr.Close()
+
+	err = os.Setenv("STORAGE_EMULATOR_HOST", svr.Addr)
+	testutil.Ok(t, err)
+
+	cfg := Config{
+		Bucket:   "test-bucket",
+		Endpoint: "https://storage.europe-west3.rep.googleapis.com",
+		noAuth:   true,
+	}
+
+	bkt, err := NewBucketWithConfig(context.Background(), log.NewNopLogger(), cfg, "test", nil)
+	testutil.Ok(t, err)
+	testutil.Assert(t, bkt != nil, "expected bucket to be created with custom endpoint")
+}
+
 func TestNewBucketWithErrorRoundTripper(t *testing.T) {
 	cfg := Config{
 		Bucket:         "test-bucket",


### PR DESCRIPTION
## Problem

Thanos currently does not support configuring a custom API endpoint for Google Cloud Storage. This prevents using [GCS regional endpoints](https://cloud.google.com/storage/docs/regional-endpoints) or GCS-compatible storage backends.

Fixes: thanos-io/thanos#7862

## Solution

Added an `endpoint` field to the GCS `Config` struct. When set, it is passed as `option.WithEndpoint()` when creating the GCS storage client.

### Configuration example

```yaml
type: GCS
config:
  bucket: my-bucket
  endpoint: https://storage.europe-west3.rep.googleapis.com
```

## Changes

- **providers/gcs/gcs.go**: Added `Endpoint` field to `Config` struct and wired it through `NewBucketWithConfig` via `option.WithEndpoint()`
- **providers/gcs/gcs_test.go**: Added tests for endpoint config parsing and bucket creation with custom endpoint

## Notes

- Follows the same pattern used by the S3 provider for custom endpoints
- When `endpoint` is empty (default), behavior is unchanged
- Compatible with both HTTP and gRPC client modes