### PR TITLE
gcs: add custom_endpoint config option for GCS regional endpoints

### DIFF
--- a/providers/gcs/gcs.go
+++ b/providers/gcs/gcs.go
@@ -59,6 +59,11 @@ type Config struct {
 	// Overrides the default gcs storage client behavior if this value is greater than 0.
 	// Set this to 1 to disable retries.
 	MaxRetries int `yaml:"max_retries"`
+
+	// CustomEndpoint allows overriding the default Google Cloud Storage API endpoint.
+	// This is useful for connecting to GCS-compatible services or GCP regional endpoints.
+	// See https://cloud.google.com/storage/docs/regional-endpoints for details.
+	CustomEndpoint string `yaml:"custom_endpoint"`
 }
 
 // Bucket implements the store.Bucket and shipper.Bucket interfaces against GCS.
@@ -108,6 +113,9 @@ func NewBucketWithConfig(ctx context.Context, logger log.Logger, gc Config, comp
 	}
 	if gc.noAuth {
 		opts = append(opts, option.WithoutAuthentication())
+	}
+	if gc.CustomEndpoint != "" {
+		opts = append(opts, option.WithEndpoint(gc.CustomEndpoint))
 	}
 	opts = append(opts,
 		option.WithUserAgent(fmt.Sprintf("thanos-%s/%s (%s)", component, version.Version, runtime.Version())),


### PR DESCRIPTION
## What does this PR do?

Adds a `custom_endpoint` configuration field to the GCS `Config` struct, allowing users to override the default Google Cloud Storage API endpoint.

This is useful for:
- Connecting to [GCS regional endpoints](https://cloud.google.com/storage/docs/regional-endpoints) for data residency compliance
- Connecting to GCS-compatible storage services

When set, the endpoint is passed to the GCS client via `option.WithEndpoint()`.

**New config field:**
```yaml
type: GCS
config:
  bucket: my-bucket
  custom_endpoint: "https://storage.us-east4.rep.googleapis.com"
```

## Checklist

- [x] Added `custom_endpoint` field to `Config` struct with YAML tag `custom_endpoint`
- [x] Applied `option.WithEndpoint()` when the field is non-empty in `NewBucketWithConfig`
- [x] Backward compatible (empty string means no override, preserves existing behavior)

Closes https://github.com/thanos-io/thanos/issues/7862
