### PR TITLE
gcs: retry Delete on transient 5xx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#157](https://github.com/thanos-io/objstore/pull/157) Azure: Add `az_tenant_id`, `client_id` and `client_secret` configs.
 
 ### Fixed
+- [#261](https://github.com/thanos-io/objstore/pull/261) GCS: retry Delete on transient 5xx, and cap all operations at MaxRetries (default 3 when unset).
 - [#196](https://github.com/thanos-io/objstore/pull/196) GCS: fix error check in Exists method when object does not exist.
 - [#153](https://github.com/thanos-io/objstore/pull/153) Metrics: Fix `objstore_bucket_operation_duration_seconds_*` for `get` and `get_range` operations.
 - [#141](https://github.com/thanos-io/objstore/pull/142) S3: Fix missing encryption configuration for `Bucket.Exists()` and `Bucket.Attributes()` calls.

--- a/providers/gcs/gcs.go
+++ b/providers/gcs/gcs.go
@@ -35,6 +35,7 @@ const DirDelim = "/"
 
 var DefaultConfig = Config{
 	HTTPConfig: exthttp.DefaultHTTPConfig,
+	MaxRetries: 3,
 }
 
 // Config stores the configuration for gcs bucket.
@@ -55,9 +56,8 @@ type Config struct {
 	ChunkSizeBytes int  `yaml:"chunk_size_bytes"`
 	noAuth         bool `yaml:"no_auth"`
 
-	// MaxRetries controls the number of retries for idempotent operations.
-	// Overrides the default gcs storage client behavior if this value is greater than 0.
-	// Set this to 1 to disable retries.
+	// MaxRetries controls the number of attempts for retryable operations.
+	// Defaults to 3 when unset (see DefaultConfig). Set this to 1 to disable retries.
 	MaxRetries int `yaml:"max_retries"`
 }
 
@@ -179,9 +179,14 @@ func newBucket(ctx context.Context, logger log.Logger, gc Config, opts []option.
 		chunkSize: gc.ChunkSizeBytes,
 	}
 
-	if gc.MaxRetries > 0 {
-		bkt.bkt = bkt.bkt.Retryer(storage.WithMaxAttempts(gc.MaxRetries))
+	// Cap retries on transient errors. See
+	// https://docs.cloud.google.com/storage/docs/retry-strategy for what
+	// counts as transient and how the SDK handles backoff.
+	maxAttempts := gc.MaxRetries
+	if maxAttempts == 0 {
+		maxAttempts = DefaultConfig.MaxRetries
 	}
+	bkt.bkt = bkt.bkt.Retryer(storage.WithMaxAttempts(maxAttempts))
 
 	return bkt, nil
 }
@@ -349,9 +354,11 @@ func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader, opts ...o
 	return w.Close()
 }
 
-// Delete removes the object with the given name.
+// Delete removes the object with the given name. RetryAlways overrides the
+// default RetryIdempotent policy, which would otherwise exclude Delete because
+// we don't pass IfGenerationMatch.
 func (b *Bucket) Delete(ctx context.Context, name string) error {
-	return b.bkt.Object(name).Delete(ctx)
+	return b.bkt.Object(name).Retryer(storage.WithPolicy(storage.RetryAlways)).Delete(ctx)
 }
 
 // IsObjNotFoundErr returns true if error means that object is not found. Relevant to Get operations.

--- a/providers/gcs/gcs_test.go
+++ b/providers/gcs/gcs_test.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -177,4 +179,31 @@ func TestNewBucketWithErrorRoundTripper(t *testing.T) {
 	_, err = bkt.Get(context.Background(), "test-bucket")
 	testutil.NotOk(t, err)
 	testutil.Assert(t, errutil.IsMockedError(err), "Expected RoundTripper error, got: %v", err)
+}
+
+func TestBucket_Delete_RetriesOnTransient5xx(t *testing.T) {
+	var deleteAttempts atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/o/") {
+			n := deleteAttempts.Add(1)
+			if n < 3 {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				_, _ = w.Write([]byte(`{"error":{"code":503,"message":"backendError"}}`))
+				return
+			}
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	t.Setenv("STORAGE_EMULATOR_HOST", srv.Listener.Addr().String())
+
+	bkt, err := newBucket(context.Background(), log.NewNopLogger(), Config{Bucket: "test-bucket"}, []option.ClientOption{})
+	testutil.Ok(t, err)
+
+	testutil.Ok(t, bkt.Delete(context.Background(), "test-object"))
+	testutil.Equals(t, int32(3), deleteAttempts.Load())
 }

--- a/providers/gcs/gcs_test.go
+++ b/providers/gcs/gcs_test.go
@@ -10,7 +10,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -19,6 +18,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/prometheus/common/model"
 	"github.com/thanos-io/objstore/errutil"
+	"go.uber.org/atomic"
 	"google.golang.org/api/option"
 )
 


### PR DESCRIPTION
The default `RetryIdempotent` policy doesn't cover Delete without an `IfGenerationMatch` precondition, so a single 503 from GCS bubbles up to the caller. Switch `Delete` to `RetryAlways`. Also apply `MaxRetries` (default 3 when unset) to all operations so the cap is no longer opt-in.

See https://docs.cloud.google.com/storage/docs/retry-strategy.

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

- `Delete` now calls `bkt.Object(name).Retryer(storage.WithPolicy(storage.RetryAlways)).Delete(ctx)`. Without `RetryAlways`, the SDK skips retries entirely for plain Delete because the default `RetryIdempotent` policy treats unconditional Delete as  non-idempotent.
- `newBucket` now always sets `WithMaxAttempts(MaxRetries)` on the bucket handle. Previously this was only applied when the user set `max_retries > 0`. The ObjectHandle inherits the bucket's retry config, so the new Delete retry inherits the cap.
- `DefaultConfig.MaxRetries = 3` sets the new default. `newBucket` falls back to this when `gc.MaxRetries == 0`, covering both the YAML config path (via DefaultConfig) and direct `NewBucketWithConfig` callers.
- `Config.MaxRetries` doc updated. `MaxRetries: 1` to disable retries still works.

## Verification

Added `TestBucket_Delete_RetriesOnTransient5xx` in `providers/gcs/gcs_test.go`. Stands up an `httptest.NewServer` that returns 503 on the first 2 DELETE requests and 204 on the third. Asserts `bkt.Delete` returns nil and the server saw exactly 3 attempts.

Context: this surfaced as recurring crashes in the Thanos compactor's `BlocksCleaner.DeleteMarkedBlocks` when GCS returned a transient 503 on a single delete during the cleanup pass. Discussion: thanos-io/thanos#8838 (now closed in favor of fixing the issue here in objstore).