### PR TITLE
s3: tidy up transport construction

### DIFF
--- a/providers/s3/s3.go
+++ b/providers/s3/s3.go
@@ -247,12 +247,14 @@ func NewBucketWithConfig(logger log.Logger, config Config, component string, wra
 	// Check if a roundtripper has been set in the config
 	// otherwise build the default transport.
 	var tpt http.RoundTripper
-	tpt, err := exthttp.DefaultTransport(config.HTTPConfig)
-	if err != nil {
-		return nil, err
-	}
 	if config.HTTPConfig.Transport != nil {
 		tpt = config.HTTPConfig.Transport
+	} else {
+		var err error
+		tpt, err = exthttp.DefaultTransport(config.HTTPConfig)
+		if err != nil {
+			return nil, err
+		}
 	}
 	if wrapRoundtripper != nil {
 		tpt = wrapRoundtripper(tpt)


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Only build the default transport if none is set in config.
This is what the comment already said; it confused me that the code was doing extra work.

## Verification

It's simple enough to eyeball.  Hopefully there are tests.