### PR TITLE
feat(HTTPConfig): expose config to force-attempt HTTP/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#63](https://github.com/thanos-io/objstore/pull/63) Implement a `IterWithAttributes` method on the bucket client.
 - [#155](https://github.com/thanos-io/objstore/pull/155) Add a `Provider` method on `objstore.Client`.
 - [#163](https://github.com/thanos-io/objstore/pull/145) Add a `NewBucketFromConfig` constructor method for creating a client from an existing `BucketConfig` object.
-- [#XXX](https://github.com/thanos-io/objstore/pull/XXX) *: Add `force_attempt_http2` option to `http_config`.
+- [#266](https://github.com/thanos-io/objstore/pull/266) *: Add `force_attempt_http2` option to `http_config` to re-enable HTTP/2 for the custom transport.
 
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#63](https://github.com/thanos-io/objstore/pull/63) Implement a `IterWithAttributes` method on the bucket client.
 - [#155](https://github.com/thanos-io/objstore/pull/155) Add a `Provider` method on `objstore.Client`.
 - [#163](https://github.com/thanos-io/objstore/pull/145) Add a `NewBucketFromConfig` constructor method for creating a client from an existing `BucketConfig` object.
+- [#XXX](https://github.com/thanos-io/objstore/pull/XXX) *: Add `force_attempt_http2` option to `http_config`.
 
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ config:
       key_file: ""
       server_name: ""
       insecure_skip_verify: false
+    force_attempt_http2: false
     disable_compression: false
   trace:
     enable: false
@@ -405,6 +406,7 @@ config:
       key_file: ""
       server_name: ""
       insecure_skip_verify: false
+    force_attempt_http2: false
     disable_compression: false
   chunk_size_bytes: 0
   max_retries: 0
@@ -511,6 +513,7 @@ config:
       key_file: ""
       server_name: ""
       insecure_skip_verify: false
+    force_attempt_http2: false
     disable_compression: false
   msi_resource: ""
 prefix: ""
@@ -574,6 +577,7 @@ config:
       key_file: ""
       server_name: ""
       insecure_skip_verify: false
+    force_attempt_http2: false
     disable_compression: false
 prefix: ""
 ```
@@ -609,6 +613,7 @@ config:
       key_file: ""
       server_name: ""
       insecure_skip_verify: false
+    force_attempt_http2: false
     disable_compression: false
 prefix: ""
 ```
@@ -775,6 +780,7 @@ config:
       key_file: ""
       server_name: ""
       insecure_skip_verify: false
+    force_attempt_http2: false
     disable_compression: false
 prefix: ""
 ```

--- a/exthttp/transport.go
+++ b/exthttp/transport.go
@@ -37,6 +37,7 @@ type HTTPConfig struct {
 	Transport http.RoundTripper `yaml:"-"`
 
 	TLSConfig          TLSConfig `yaml:"tls_config"`
+	ForceAttemptHTTP2  bool      `yaml:"force_attempt_http2"`
 	DisableCompression bool      `yaml:"disable_compression"`
 }
 
@@ -74,6 +75,7 @@ func DefaultTransport(config HTTPConfig) (*http.Transport, error) {
 		// content-encoding set to `gzip`.
 		//
 		// Refer: https://golang.org/src/net/http/transport.go?h=roundTrip#L1843.
-		TLSClientConfig: tlsConfig,
+		TLSClientConfig:   tlsConfig,
+		ForceAttemptHTTP2: config.ForceAttemptHTTP2,
 	}, nil
 }

--- a/providers/azure/azure_test.go
+++ b/providers/azure/azure_test.go
@@ -204,6 +204,10 @@ func TestParseConfig_DefaultHTTPConfig(t *testing.T) {
 	if cfg.HTTPConfig.InsecureSkipVerify {
 		t.Errorf("parsing of insecure_skip_verify failed: got %v, expected %v", cfg.HTTPConfig.InsecureSkipVerify, false)
 	}
+
+	if cfg.HTTPConfig.ForceAttemptHTTP2 {
+		t.Errorf("parsing of force_attempt_http2 failed: got %v, expected %v", cfg.HTTPConfig.ForceAttemptHTTP2, false)
+	}
 }
 
 func TestParseConfig_CustomHTTPConfigWithTLS(t *testing.T) {
@@ -218,6 +222,7 @@ http_config:
     key_file: /certs/key.key
     server_name: server
     insecure_skip_verify: false
+  force_attempt_http2: true
   `)
 	cfg, err := parseConfig(input)
 	testutil.Ok(t, err)
@@ -227,6 +232,7 @@ http_config:
 	testutil.Equals(t, "/certs/key.key", cfg.HTTPConfig.TLSConfig.KeyFile)
 	testutil.Equals(t, "server", cfg.HTTPConfig.TLSConfig.ServerName)
 	testutil.Equals(t, false, cfg.HTTPConfig.TLSConfig.InsecureSkipVerify)
+	testutil.Equals(t, true, cfg.HTTPConfig.ForceAttemptHTTP2)
 }
 
 func TestParseConfig_CustomLegacyInsecureSkipVerify(t *testing.T) {

--- a/providers/cos/cos_test.go
+++ b/providers/cos/cos_test.go
@@ -55,6 +55,28 @@ http_config:
 			},
 			wantErr: false,
 		},
+		{
+			name: "force_attempt_http2",
+			args: args{
+				conf: []byte(`
+http_config:
+  force_attempt_http2: true
+`),
+			},
+			want: Config{
+				HTTPConfig: exthttp.HTTPConfig{
+					IdleConnTimeout:       model.Duration(90 * time.Second),
+					ResponseHeaderTimeout: model.Duration(2 * time.Minute),
+					TLSHandshakeTimeout:   model.Duration(10 * time.Second),
+					ExpectContinueTimeout: model.Duration(1 * time.Second),
+					MaxIdleConns:          100,
+					MaxIdleConnsPerHost:   100,
+					MaxConnsPerHost:       0,
+					ForceAttemptHTTP2:     true,
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/providers/gcs/gcs_test.go
+++ b/providers/gcs/gcs_test.go
@@ -117,6 +117,7 @@ func TestParseConfig_HTTPConfig(t *testing.T) {
 				testutil.Equals(t, cfg.HTTPConfig.IdleConnTimeout, model.Duration(90*time.Second))
 				testutil.Equals(t, cfg.HTTPConfig.ResponseHeaderTimeout, model.Duration(2*time.Minute))
 				testutil.Equals(t, cfg.HTTPConfig.InsecureSkipVerify, false)
+				testutil.Equals(t, cfg.HTTPConfig.ForceAttemptHTTP2, false)
 			},
 		},
 		{
@@ -125,11 +126,13 @@ func TestParseConfig_HTTPConfig(t *testing.T) {
 http_config:
   insecure_skip_verify: true
   idle_conn_timeout: 50s
-  response_header_timeout: 1m`,
+  response_header_timeout: 1m
+  force_attempt_http2: true`,
 			assertions: func(cfg Config) {
 				testutil.Equals(t, cfg.HTTPConfig.IdleConnTimeout, model.Duration(50*time.Second))
 				testutil.Equals(t, cfg.HTTPConfig.ResponseHeaderTimeout, model.Duration(1*time.Minute))
 				testutil.Equals(t, cfg.HTTPConfig.InsecureSkipVerify, true)
+				testutil.Equals(t, cfg.HTTPConfig.ForceAttemptHTTP2, true)
 			},
 		},
 		{

--- a/providers/s3/s3_test.go
+++ b/providers/s3/s3_test.go
@@ -141,6 +141,10 @@ insecure: false`)
 	if cfg.HTTPConfig.InsecureSkipVerify {
 		t.Errorf("parsing of insecure_skip_verify failed: got %v, expected %v", cfg.HTTPConfig.InsecureSkipVerify, false)
 	}
+
+	if cfg.HTTPConfig.ForceAttemptHTTP2 {
+		t.Errorf("parsing of force_attempt_http2 failed: got %v, expected %v", cfg.HTTPConfig.ForceAttemptHTTP2, false)
+	}
 }
 
 func TestParseConfig_CustomHTTPConfig(t *testing.T) {
@@ -149,7 +153,8 @@ insecure: false
 http_config:
   insecure_skip_verify: true
   idle_conn_timeout: 50s
-  response_header_timeout: 1m`)
+  response_header_timeout: 1m
+  force_attempt_http2: true`)
 	cfg, err := parseConfig(input)
 	testutil.Ok(t, err)
 
@@ -165,6 +170,10 @@ http_config:
 
 	if !cfg.HTTPConfig.InsecureSkipVerify {
 		t.Errorf("parsing of insecure_skip_verify failed: got %v, expected %v", cfg.HTTPConfig.InsecureSkipVerify, false)
+	}
+
+	if !cfg.HTTPConfig.ForceAttemptHTTP2 {
+		t.Errorf("parsing of force_attempt_http2 failed: got %v, expected %v", cfg.HTTPConfig.ForceAttemptHTTP2, true)
 	}
 }
 

--- a/providers/swift/swift_test.go
+++ b/providers/swift/swift_test.go
@@ -64,6 +64,7 @@ http_config:
 	testutil.Equals(t, model.Duration(90*time.Second), cfg.HTTPConfig.IdleConnTimeout)
 	testutil.Equals(t, model.Duration(2*time.Minute), cfg.HTTPConfig.ResponseHeaderTimeout)
 	testutil.Equals(t, false, cfg.HTTPConfig.InsecureSkipVerify)
+	testutil.Equals(t, false, cfg.HTTPConfig.ForceAttemptHTTP2)
 
 }
 


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "s3:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos Objstore <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/objstore/pull/<PR-id>
    <Component> Component affected by your changes such as s3, azure, cos.
-->

* [X] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Added flag to pass through `ForceAttemptHTTP2` - we are experiencing extremely high tail latencies with GCS that can be mitigated in part by HTTP/2, at least in our benchmarks so far.

This deals with the Go `http.Transport`'s design choice of silently downgrading to HTTP/1.1 when a custom `Transport` is used:
```go
	// ForceAttemptHTTP2 controls whether HTTP/2 is enabled when a non-zero
	// Dial, DialTLS, or DialContext func or TLSClientConfig is provided.
	// By default, use of any those fields conservatively disables HTTP/2.
	// To use a custom dialer or TLS config and still attempt HTTP/2
	// upgrades, set this to true.
	ForceAttemptHTTP2 [bool](https://pkg.go.dev/builtin#bool)
```

## Verification

Test are added for config parsing & validation - we verified the performance difference in a benchmark [here](https://github.com/grafana/mimir/pull/15861/changes) where we just hardcoded the flag in `objstore/exthttp/transport.go`.
