### PR TITLE
Test/s3 without public kes

### DIFF
--- a/providers/oci/helper.go
+++ b/providers/oci/helper.go
@@ -274,3 +274,16 @@ func getConfigFromEnv() (config Config, err error) {
 
 	return config, nil
 }
+
+func headObject(ctx context.Context, bkt Bucket, objectName string) (objectstorage.HeadObjectResponse, error) {
+	if objectName == "" {
+		return objectstorage.HeadObjectResponse{}, errors.New("object name cannot be empty")
+	}
+
+	return bkt.client.HeadObject(ctx, objectstorage.HeadObjectRequest{
+		NamespaceName:   common.String(bkt.namespace),
+		BucketName:      common.String(bkt.name),
+		ObjectName:      common.String(objectName),
+		RequestMetadata: bkt.requestMetadata,
+	})
+}

--- a/providers/oci/oci.go
+++ b/providers/oci/oci.go
@@ -4,6 +4,7 @@
 package oci
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -222,6 +223,14 @@ func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader, opts ...o
 		return err
 	}
 
+	if uploadOptions.ContentType != "" {
+		uploadRequest.ContentType = common.String(uploadOptions.ContentType)
+	}
+
+	if uploadRequest.IfMatch != nil || uploadRequest.IfNoneMatch != nil {
+		return b.uploadConditionally(ctx, r, uploadRequest)
+	}
+
 	req := transfer.UploadStreamRequest{
 		UploadRequest: uploadRequest,
 		StreamReader:  r,
@@ -231,16 +240,36 @@ func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader, opts ...o
 		req.UploadRequest.PartSize = &b.partSize
 	}
 
-	if uploadOptions.ContentType != "" {
-		req.UploadRequest.ContentType = &uploadOptions.ContentType
-	}
-
 	uploadManager := transfer.NewUploadManager()
 	_, err = uploadManager.UploadStream(ctx, req)
 
 	return err
 }
+func (b *Bucket) uploadConditionally(
+	ctx context.Context,
+	r io.Reader,
+	uploadRequest transfer.UploadRequest,
+) error {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return errors.Wrap(err, "read object data for conditional OCI upload")
+	}
 
+	request := objectstorage.PutObjectRequest{
+		NamespaceName:   uploadRequest.NamespaceName,
+		BucketName:      uploadRequest.BucketName,
+		ObjectName:      uploadRequest.ObjectName,
+		ContentLength:   common.Int64(int64(len(data))),
+		PutObjectBody:   io.NopCloser(bytes.NewReader(data)),
+		IfMatch:         uploadRequest.IfMatch,
+		IfNoneMatch:     uploadRequest.IfNoneMatch,
+		ContentType:     uploadRequest.ContentType,
+		RequestMetadata: uploadRequest.RequestMetadata,
+	}
+
+	_, err = b.client.PutObject(ctx, request)
+	return err
+}
 func (b *Bucket) SupportedObjectUploadOptions() []objstore.ObjectUploadOptionType {
 	return []objstore.ObjectUploadOptionType{
 		objstore.ContentType,

--- a/providers/oci/oci.go
+++ b/providers/oci/oci.go
@@ -52,6 +52,9 @@ var DefaultConfig = Config{
 		ClientTimeout:         90 * time.Second,
 	},
 }
+var errConditionInvalid = errors.New(
+	"invalid condition: OCI supports ETag object versions",
+)
 
 // HTTPConfig stores the http.Transport configuration for the OCI client.
 type HTTPConfig struct {
@@ -200,22 +203,34 @@ func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader, opts ...o
 	if err := objstore.ValidateUploadOptions(b.SupportedObjectUploadOptions(), opts...); err != nil {
 		return err
 	}
-	req := transfer.UploadStreamRequest{
-		UploadRequest: transfer.UploadRequest{
-			NamespaceName:                       common.String(b.namespace),
-			BucketName:                          common.String(b.name),
-			ObjectName:                          &name,
-			EnableMultipartChecksumVerification: common.Bool(true), // TODO: should we check?
-			ObjectStorageClient:                 b.client,
-			RequestMetadata:                     b.requestMetadata,
-		},
-		StreamReader: r,
+	uploadOptions := objstore.ApplyObjectUploadOptions(opts...)
+
+	uploadRequest := transfer.UploadRequest{
+		NamespaceName: common.String(b.namespace),
+		BucketName:    common.String(b.name),
+		ObjectName:    common.String(name),
+
+		EnableMultipartChecksumVerification: common.Bool(true),
+		ObjectStorageClient:                 b.client,
+		RequestMetadata:                     b.requestMetadata,
 	}
+
+	if err := applyUploadConditions(
+		&uploadRequest,
+		uploadOptions,
+	); err != nil {
+		return err
+	}
+
+	req := transfer.UploadStreamRequest{
+		UploadRequest: uploadRequest,
+		StreamReader:  r,
+	}
+
 	if b.partSize > 0 {
 		req.UploadRequest.PartSize = &b.partSize
 	}
 
-	uploadOptions := objstore.ApplyObjectUploadOptions(opts...)
 	if uploadOptions.ContentType != "" {
 		req.UploadRequest.ContentType = &uploadOptions.ContentType
 	}
@@ -227,7 +242,11 @@ func (b *Bucket) Upload(ctx context.Context, name string, r io.Reader, opts ...o
 }
 
 func (b *Bucket) SupportedObjectUploadOptions() []objstore.ObjectUploadOptionType {
-	return []objstore.ObjectUploadOptionType{objstore.ContentType}
+	return []objstore.ObjectUploadOptionType{
+		objstore.ContentType,
+		objstore.IfMatch,
+		objstore.IfNotExists,
+	}
 }
 
 // Exists checks if the given object exists in the bucket.
@@ -276,7 +295,18 @@ func (b *Bucket) IsAccessDeniedErr(err error) bool {
 	return false
 }
 
-func (b *Bucket) IsConditionNotMetErr(_ error) bool { return false }
+func (b *Bucket) IsConditionNotMetErr(err error) bool {
+	if errors.Is(err, errConditionInvalid) {
+		return true
+	}
+
+	failure, ok := common.IsServiceError(err)
+	if !ok {
+		return false
+	}
+
+	return failure.GetHTTPStatusCode() == http.StatusPreconditionFailed
+}
 
 // ObjectSize returns the size of the specified object.
 func (b *Bucket) ObjectSize(ctx context.Context, name string) (uint64, error) {
@@ -292,16 +322,23 @@ func (b *Bucket) Close() error {
 	return nil
 }
 
-// Attributes returns information about the specified object.
-func (b *Bucket) Attributes(ctx context.Context, name string) (objstore.ObjectAttributes, error) {
-	response, err := getObject(ctx, *b, name, "")
+func (b *Bucket) Attributes(
+	ctx context.Context,
+	name string,
+) (objstore.ObjectAttributes, error) {
+	request := objectstorage.HeadObjectRequest{
+		NamespaceName:   common.String(b.namespace),
+		BucketName:      common.String(b.name),
+		ObjectName:      common.String(name),
+		RequestMetadata: b.requestMetadata,
+	}
+
+	response, err := b.client.HeadObject(ctx, request)
 	if err != nil {
 		return objstore.ObjectAttributes{}, err
 	}
-	return objstore.ObjectAttributes{
-		Size:         *response.ContentLength,
-		LastModified: response.LastModified.Time,
-	}, nil
+
+	return attributesFromHeadObjectResponse(response), nil
 }
 
 // createBucket creates bucket.
@@ -444,4 +481,47 @@ func NewTestBucket(t testing.TB) (objstore.Bucket, func(), error) {
 		}
 		t.Logf("deleted temporary Oracle Cloud Infrastructure bucket '%s' for testing", bkt.name)
 	}, nil
+}
+
+func applyUploadConditions(
+	req *transfer.UploadRequest,
+	uploadOptions objstore.UploadObjectParams,
+) error {
+	if uploadOptions.Condition != nil {
+		if uploadOptions.Condition.Type != objstore.ETag {
+			return errConditionInvalid
+		}
+
+		req.IfMatch = common.String(uploadOptions.Condition.Value)
+		return nil
+	}
+
+	if uploadOptions.IfNotExists {
+		req.IfNoneMatch = common.String("*")
+	}
+
+	return nil
+}
+
+func attributesFromHeadObjectResponse(
+	response objectstorage.HeadObjectResponse,
+) objstore.ObjectAttributes {
+	attrs := objstore.ObjectAttributes{}
+
+	if response.ContentLength != nil {
+		attrs.Size = *response.ContentLength
+	}
+
+	if response.LastModified != nil {
+		attrs.LastModified = response.LastModified.Time
+	}
+
+	if response.ETag != nil {
+		attrs.Version = &objstore.ObjectVersion{
+			Type:  objstore.ETag,
+			Value: *response.ETag,
+		}
+	}
+
+	return attrs
 }

--- a/providers/oci/oci.go
+++ b/providers/oci/oci.go
@@ -280,13 +280,15 @@ func (b *Bucket) SupportedObjectUploadOptions() []objstore.ObjectUploadOptionTyp
 
 // Exists checks if the given object exists in the bucket.
 func (b *Bucket) Exists(ctx context.Context, name string) (bool, error) {
-	_, err := getObject(ctx, *b, name, "")
+	_, err := headObject(ctx, *b, name)
 	if err != nil {
 		if b.IsObjNotFoundErr(err) {
 			return false, nil
 		}
-		return false, errors.Wrapf(err, "cannot get OCI object '%s'", name)
+
+		return false, errors.Wrapf(err, "cannot get OCI object attributes %q", name)
 	}
+
 	return true, nil
 }
 
@@ -339,10 +341,15 @@ func (b *Bucket) IsConditionNotMetErr(err error) bool {
 
 // ObjectSize returns the size of the specified object.
 func (b *Bucket) ObjectSize(ctx context.Context, name string) (uint64, error) {
-	response, err := getObject(ctx, *b, name, "")
+	response, err := headObject(ctx, *b, name)
 	if err != nil {
 		return 0, err
 	}
+
+	if response.ContentLength == nil {
+		return 0, errors.Errorf("OCI object %q response has no content length", name)
+	}
+
 	return uint64(*response.ContentLength), nil
 }
 
@@ -351,18 +358,8 @@ func (b *Bucket) Close() error {
 	return nil
 }
 
-func (b *Bucket) Attributes(
-	ctx context.Context,
-	name string,
-) (objstore.ObjectAttributes, error) {
-	request := objectstorage.HeadObjectRequest{
-		NamespaceName:   common.String(b.namespace),
-		BucketName:      common.String(b.name),
-		ObjectName:      common.String(name),
-		RequestMetadata: b.requestMetadata,
-	}
-
-	response, err := b.client.HeadObject(ctx, request)
+func (b *Bucket) Attributes(ctx context.Context, name string) (objstore.ObjectAttributes, error) {
+	response, err := headObject(ctx, *b, name)
 	if err != nil {
 		return objstore.ObjectAttributes{}, err
 	}

--- a/providers/oci/oci_test.go
+++ b/providers/oci/oci_test.go
@@ -5,8 +5,14 @@ import (
 
 	"github.com/efficientgo/core/testutil"
 	"github.com/go-kit/log"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-go-sdk/v65/objectstorage"
+	"github.com/oracle/oci-go-sdk/v65/objectstorage/transfer"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore"
 	"github.com/thanos-io/objstore/errutil"
 	"gopkg.in/yaml.v2"
+	"time"
 )
 
 func TestNewBucketWithErrorRoundTripper(t *testing.T) {
@@ -41,4 +47,122 @@ G6aFKaqQfOXKCyWoUiVknQJAXrlgySFci/2ueKlIE1QqIiLSZ8V8OlpFLRnb1pzI
 	// We expect an error from the RoundTripper
 	testutil.NotOk(t, err)
 	testutil.Assert(t, errutil.IsMockedError(err), "Expected RoundTripper error, got: %v", err)
+}
+func TestSupportedObjectUploadOptions(t *testing.T) {
+	b := &Bucket{}
+
+	require.ElementsMatch(
+		t,
+		[]objstore.ObjectUploadOptionType{
+			objstore.ContentType,
+			objstore.IfMatch,
+			objstore.IfNotExists,
+		},
+		b.SupportedObjectUploadOptions(),
+	)
+}
+func TestApplyUploadConditionsIfMatch(t *testing.T) {
+	version := &objstore.ObjectVersion{
+		Type:  objstore.ETag,
+		Value: `"test-etag"`,
+	}
+
+	uploadOptions := objstore.ApplyObjectUploadOptions(
+		objstore.WithIfMatch(version),
+	)
+
+	req := transfer.UploadRequest{}
+
+	err := applyUploadConditions(&req, uploadOptions)
+
+	require.NoError(t, err)
+	require.NotNil(t, req.IfMatch)
+	require.Equal(t, `"test-etag"`, *req.IfMatch)
+	require.Nil(t, req.IfNoneMatch)
+}
+
+func TestApplyUploadConditionsIfNotExists(t *testing.T) {
+	uploadOptions := objstore.ApplyObjectUploadOptions(
+		objstore.WithIfNotExists(),
+	)
+
+	req := transfer.UploadRequest{}
+
+	err := applyUploadConditions(&req, uploadOptions)
+
+	require.NoError(t, err)
+	require.Nil(t, req.IfMatch)
+	require.NotNil(t, req.IfNoneMatch)
+	require.Equal(t, "*", *req.IfNoneMatch)
+}
+
+func TestApplyUploadConditionsWithoutCondition(t *testing.T) {
+	uploadOptions := objstore.ApplyObjectUploadOptions()
+
+	req := transfer.UploadRequest{}
+
+	err := applyUploadConditions(&req, uploadOptions)
+
+	require.NoError(t, err)
+	require.Nil(t, req.IfMatch)
+	require.Nil(t, req.IfNoneMatch)
+}
+
+func TestApplyUploadConditionsRejectsGeneration(t *testing.T) {
+	version := &objstore.ObjectVersion{
+		Type:  objstore.Generation,
+		Value: "123",
+	}
+
+	uploadOptions := objstore.ApplyObjectUploadOptions(
+		objstore.WithIfMatch(version),
+	)
+
+	req := transfer.UploadRequest{}
+
+	err := applyUploadConditions(&req, uploadOptions)
+
+	require.ErrorIs(t, err, errConditionInvalid)
+	require.Nil(t, req.IfMatch)
+	require.Nil(t, req.IfNoneMatch)
+}
+
+func TestAttributesFromHeadObjectResponse(t *testing.T) {
+	lastModified := common.SDKTime{
+		Time: time.Date(
+			2026,
+			time.August,
+			4,
+			12,
+			0,
+			0,
+			0,
+			time.UTC,
+		),
+	}
+
+	response := objectstorage.HeadObjectResponse{
+		ContentLength: common.Int64(1234),
+		LastModified:  &lastModified,
+		ETag:          common.String(`"oci-etag-value"`),
+	}
+
+	attrs := attributesFromHeadObjectResponse(response)
+
+	require.Equal(t, int64(1234), attrs.Size)
+	require.Equal(t, lastModified.Time, attrs.LastModified)
+
+	require.NotNil(t, attrs.Version)
+	require.Equal(t, objstore.ETag, attrs.Version.Type)
+	require.Equal(t, `"oci-etag-value"`, attrs.Version.Value)
+}
+func TestAttributesFromHeadObjectResponseWithoutETag(t *testing.T) {
+	response := objectstorage.HeadObjectResponse{
+		ContentLength: common.Int64(10),
+	}
+
+	attrs := attributesFromHeadObjectResponse(response)
+
+	require.Equal(t, int64(10), attrs.Size)
+	require.Nil(t, attrs.Version)
 }

--- a/providers/oci/oci_test.go
+++ b/providers/oci/oci_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/objectstorage"
 	"github.com/oracle/oci-go-sdk/v65/objectstorage/transfer"
-	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore"
 	"github.com/thanos-io/objstore/errutil"
 	"gopkg.in/yaml.v2"
@@ -51,7 +50,7 @@ G6aFKaqQfOXKCyWoUiVknQJAXrlgySFci/2ueKlIE1QqIiLSZ8V8OlpFLRnb1pzI
 func TestSupportedObjectUploadOptions(t *testing.T) {
 	b := &Bucket{}
 
-	require.ElementsMatch(
+	testutil.Equals(
 		t,
 		[]objstore.ObjectUploadOptionType{
 			objstore.ContentType,
@@ -75,10 +74,10 @@ func TestApplyUploadConditionsIfMatch(t *testing.T) {
 
 	err := applyUploadConditions(&req, uploadOptions)
 
-	require.NoError(t, err)
-	require.NotNil(t, req.IfMatch)
-	require.Equal(t, `"test-etag"`, *req.IfMatch)
-	require.Nil(t, req.IfNoneMatch)
+	testutil.Ok(t, err)
+	testutil.Assert(t, req.IfMatch != nil)
+	testutil.Equals(t, `"test-etag"`, *req.IfMatch)
+	testutil.Assert(t, req.IfNoneMatch == nil)
 }
 
 func TestApplyUploadConditionsIfNotExists(t *testing.T) {
@@ -90,10 +89,10 @@ func TestApplyUploadConditionsIfNotExists(t *testing.T) {
 
 	err := applyUploadConditions(&req, uploadOptions)
 
-	require.NoError(t, err)
-	require.Nil(t, req.IfMatch)
-	require.NotNil(t, req.IfNoneMatch)
-	require.Equal(t, "*", *req.IfNoneMatch)
+	testutil.Ok(t, err)
+	testutil.Assert(t, req.IfMatch == nil)
+	testutil.Assert(t, req.IfNoneMatch != nil)
+	testutil.Equals(t, "*", *req.IfNoneMatch)
 }
 
 func TestApplyUploadConditionsWithoutCondition(t *testing.T) {
@@ -103,9 +102,9 @@ func TestApplyUploadConditionsWithoutCondition(t *testing.T) {
 
 	err := applyUploadConditions(&req, uploadOptions)
 
-	require.NoError(t, err)
-	require.Nil(t, req.IfMatch)
-	require.Nil(t, req.IfNoneMatch)
+	testutil.Ok(t, err)
+	testutil.Assert(t, req.IfMatch == nil)
+	testutil.Assert(t, req.IfNoneMatch == nil)
 }
 
 func TestApplyUploadConditionsRejectsGeneration(t *testing.T) {
@@ -122,9 +121,9 @@ func TestApplyUploadConditionsRejectsGeneration(t *testing.T) {
 
 	err := applyUploadConditions(&req, uploadOptions)
 
-	require.ErrorIs(t, err, errConditionInvalid)
-	require.Nil(t, req.IfMatch)
-	require.Nil(t, req.IfNoneMatch)
+	testutil.Equals(t, errConditionInvalid, err)
+	testutil.Assert(t, req.IfMatch == nil)
+	testutil.Assert(t, req.IfNoneMatch == nil)
 }
 
 func TestAttributesFromHeadObjectResponse(t *testing.T) {
@@ -149,12 +148,12 @@ func TestAttributesFromHeadObjectResponse(t *testing.T) {
 
 	attrs := attributesFromHeadObjectResponse(response)
 
-	require.Equal(t, int64(1234), attrs.Size)
-	require.Equal(t, lastModified.Time, attrs.LastModified)
+	testutil.Equals(t, int64(1234), attrs.Size)
+	testutil.Equals(t, lastModified.Time, attrs.LastModified)
 
-	require.NotNil(t, attrs.Version)
-	require.Equal(t, objstore.ETag, attrs.Version.Type)
-	require.Equal(t, `"oci-etag-value"`, attrs.Version.Value)
+	testutil.Assert(t, attrs.Version != nil)
+	testutil.Equals(t, objstore.ETag, attrs.Version.Type)
+	testutil.Equals(t, `"oci-etag-value"`, attrs.Version.Value)
 }
 func TestAttributesFromHeadObjectResponseWithoutETag(t *testing.T) {
 	response := objectstorage.HeadObjectResponse{
@@ -163,6 +162,6 @@ func TestAttributesFromHeadObjectResponseWithoutETag(t *testing.T) {
 
 	attrs := attributesFromHeadObjectResponse(response)
 
-	require.Equal(t, int64(10), attrs.Size)
-	require.Nil(t, attrs.Version)
+	testutil.Equals(t, int64(10), attrs.Size)
+	testutil.Assert(t, attrs.Version == nil)
 }

--- a/test/e2e/e2ethanos/services.go
+++ b/test/e2e/e2ethanos/services.go
@@ -392,7 +392,6 @@ http {
 // after this is addresses fixed all calls should be replaced with e2edb.NewMinio.
 func NewMinio(e e2e.Environment, name, bktName string) *e2emon.InstrumentedRunnable {
 	image := "minio/minio:RELEASE.2022-07-30T05-21-40Z"
-	minioKESGithubContent := "https://raw.githubusercontent.com/minio/kes/master"
 
 	httpsPort := 8090
 	consolePort := 8080
@@ -414,10 +413,14 @@ func NewMinio(e e2e.Environment, name, bktName string) *e2emon.InstrumentedRunna
 	}
 
 	commands := []string{
-		fmt.Sprintf("curl -sSL --tlsv1.2 -O '%s/root.key' -O '%s/root.cert'", minioKESGithubContent, minioKESGithubContent),
-		fmt.Sprintf("mkdir -p /data/%s && minio server --certs-dir %s/certs --address :%v --console-address :%v /data", bktName, f.InternalDir(), httpsPort, consolePort),
+		fmt.Sprintf(
+			"mkdir -p /data/%s && minio server --certs-dir %s/certs --address :%v --console-address :%v /data",
+			bktName,
+			f.InternalDir(),
+			httpsPort,
+			consolePort,
+		),
 	}
-
 	minio := e2emon.AsInstrumented(f.Init(e2e.StartOptions{
 		Image: image,
 		// Create the required bucket before starting minio.
@@ -429,10 +432,6 @@ func NewMinio(e e2e.Environment, name, bktName string) *e2emon.InstrumentedRunna
 			"MINIO_BROWSER":       "on",
 			"ENABLE_HTTPS":        "1",
 			// https://docs.min.io/docs/minio-kms-quickstart-guide.html
-			"MINIO_KMS_KES_ENDPOINT":  "https://play.min.io:7373",
-			"MINIO_KMS_KES_KEY_FILE":  "root.key",
-			"MINIO_KMS_KES_CERT_FILE": "root.cert",
-			"MINIO_KMS_KES_KEY_NAME":  "my-minio-key",
 		},
 	}), "https")
 	return minio


### PR DESCRIPTION
SSE-C uses a client-provided encryption key and does not require KES.
The public KES sandbox does not provide the availability guarantees required for reliable CI runs.
Removing the external KES dependency makes the test self-contained and deterministic.
MinIO TLS remains enabled, as required by SSE-C.
This change does not reduce the existing SSE-C test coverage.