### PR TITLE
feat(http): Add connection metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#155](https://github.com/thanos-io/objstore/pull/155) Add a `Provider` method on `objstore.Client`.
 - [#163](https://github.com/thanos-io/objstore/pull/145) Add a `NewBucketFromConfig` constructor method for creating a client from an existing `BucketConfig` object.
 - [#266](https://github.com/thanos-io/objstore/pull/266) *: Add `force_attempt_http2` option to `http_config` to re-enable HTTP/2 for the custom transport.
-
+- [#271](https://github.com/thanos-io/objstore/pull/271) Add metrics `net_conntrack_dialer_conn_*_total` for every connection attempted, failed, etc.
 
 ### Changed
 - [#38](https://github.com/thanos-io/objstore/pull/38) *: Upgrade minio-go version to `v7.0.45`.

--- a/exthttp/transport.go
+++ b/exthttp/transport.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	conntrack "github.com/mwitkow/go-conntrack"
 	"github.com/prometheus/common/model"
 )
 
@@ -52,14 +53,19 @@ func DefaultTransport(config HTTPConfig) (*http.Transport, error) {
 	}
 	tlsConfig.InsecureSkipVerify = config.InsecureSkipVerify
 
-	return &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-			DualStack: true,
-		}).DialContext,
+	dialFn := (&net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+		DualStack: true,
+	}).DialContext
+	// conntrack exports metrics for every connection attempted, failed, etc.
+	dialFn = conntrack.NewDialContextFunc(
+		conntrack.DialWithDialContextFunc(dialFn),
+	)
 
+	return &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           dialFn,
 		MaxIdleConns:          config.MaxIdleConns,
 		MaxIdleConnsPerHost:   config.MaxIdleConnsPerHost,
 		IdleConnTimeout:       time.Duration(config.IdleConnTimeout),

--- a/exthttp/transport.go
+++ b/exthttp/transport.go
@@ -61,6 +61,8 @@ func DefaultTransport(config HTTPConfig) (*http.Transport, error) {
 	// conntrack exports metrics for every connection attempted, failed, etc.
 	dialFn = conntrack.NewDialContextFunc(
 		conntrack.DialWithDialContextFunc(dialFn),
+		// Can be overwritten with conntrack.DialNameToContext.
+		conntrack.DialWithName("objstore"),
 	)
 
 	return &http.Transport{

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/go-kit/log v0.2.1
 	github.com/huaweicloud/huaweicloud-sdk-go-obs v3.25.4+incompatible
 	github.com/minio/minio-go/v7 v7.0.95
+	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f
 	github.com/ncw/swift v1.0.53
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/oracle/oci-go-sdk/v65 v65.41.1
@@ -94,7 +95,6 @@ require (
 	github.com/minio/md5-simd v1.1.2 // indirect
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
 	github.com/mozillazg/go-httpheader v0.2.1 // indirect
-	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/philhofer/fwd v1.2.0 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.

## Changes

Add metrics `net_conntrack_dialer_conn_*_total` for every connection attempted, failed, closed, etc.

Conntrack metrics have a `dialer_name` label that can be useful to see connections for different reasons. 
This PR sets it to `"objstore"`, and there is a helper `conntrack.DialNameToContext` which lets you pass the name via context from the point where the dial is triggered.

## Commentary

I considered adding something to put in `dialer_name` as a parameter to `DefaultTransport`, but this seems like a rather invasive change.

## Verification

I have been using this with Loki, which uses `thanos-io/objstore` for blob access.